### PR TITLE
Added support for authenticating a request

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -71,7 +71,7 @@ public void Should_add_values_to_session()
 
 User:
 
-```
+```c#
 [Test]
 public void User_should_not_be_authenticated()
 {

--- a/README.markdown
+++ b/README.markdown
@@ -86,6 +86,7 @@ public void User_can_be_authenticated_with_convenience_method()
 	var context = new FakeHttpContext().Authenticate();
 
 	Assert.That(context.User.Identity.IsAuthenticated, Is.True);
+	Assert.That(context.Request.IsAuthenticated, Is.True);
 }
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -20,63 +20,72 @@ Examples:
 
 QueryString:
 
-	[Test]
-	public void Url_query_string_should_add_to_query_string_collection()
-	{
-		var url = new Uri("http://google.com?q=awesome&p=1");
+```c#
+[Test]
+public void Url_query_string_should_add_to_query_string_collection()
+{
+	var url = new Uri("http://google.com?q=awesome&p=1");
 
-		var request = new FakeHttpRequest(url);
+	var request = new FakeHttpRequest(url);
 
-		Assert.That(request.QueryString["q"], Is.EqualTo("awesome"));
-		Assert.That(request.QueryString["p"], Is.EqualTo("1"));
-	}
+	Assert.That(request.QueryString["q"], Is.EqualTo("awesome"));
+	Assert.That(request.QueryString["p"], Is.EqualTo("1"));
+}
 
-	[Test]
-	public void Can_access_query_string_values_by_default_indexer()
-	{
-		var request = new FakeHttpRequest();
+[Test]
+public void Can_access_query_string_values_by_default_indexer()
+{
+	var request = new FakeHttpRequest();
 
-		request.QueryString.Add("id", "3");
+	request.QueryString.Add("id", "3");
 
-		Assert.That(request["id"], Is.EqualTo("3"));
-	}
+	Assert.That(request["id"], Is.EqualTo("3"));
+}
+```
 
 Form:
 
-	[Test]
-	public void Can_access_form_values_by_default_indexer()
-	{
-		var request = new FakeHttpRequest();
+```c#
+[Test]
+public void Can_access_form_values_by_default_indexer()
+{
+	var request = new FakeHttpRequest();
 
-		request.Form.Add("color", "blue");
+	request.Form.Add("color", "blue");
 
-		Assert.That(request["color"], Is.EqualTo("blue"));
-	}
+	Assert.That(request["color"], Is.EqualTo("blue"));
+}
+```
 
 Session:
 
-	[Test]
-	public void Should_add_values_to_session()
-	{
-		var session = new FakeHttpSessionState { { "color", "red" } };
+```c#
+[Test]
+public void Should_add_values_to_session()
+{
+	var session = new FakeHttpSessionState { { "color", "red" } };
 
-		Assert.That(session["color"], Is.EqualTo("red"));
-	}
+	Assert.That(session["color"], Is.EqualTo("red"));
+}
+```
 
 User:
 
-	[Test]
-	public void User_should_not_be_authenticated()
-	{
-		var principal = new FakeHttpContext().User;
+```
+[Test]
+public void User_should_not_be_authenticated()
+{
+	var principal = new FakeHttpContext().User;
 
-		Assert.That(principal.Identity.IsAuthenticated, Is.False);
-	}
+	Assert.That(principal.Identity.IsAuthenticated, Is.False);
+}
 
-	[Test]
-	public void User_can_be_authenticated_with_convenience_method()
-	{
-		var context = new FakeHttpContext().Authenticate();
+[Test]
+public void User_can_be_authenticated_with_convenience_method()
+{
+	var context = new FakeHttpContext().Authenticate();
 
-		Assert.That(context.User.Identity.IsAuthenticated, Is.True);
-	}
+	Assert.That(context.User.Identity.IsAuthenticated, Is.True);
+}
+```
+

--- a/src/Web/FakeHttpContextExtensions.cs
+++ b/src/Web/FakeHttpContextExtensions.cs
@@ -19,6 +19,11 @@ namespace FakeN.Web
 
 		public static FakeHttpContext Authenticate(this FakeHttpContext context)
 		{
+			var request = context.Request as FakeHttpRequest;
+			if (request != null) {
+				request.SetAuthenticated(true);
+			}
+
 			return context.Set(new MutableIdentity { IsAuthenticated = true });
 		}
 

--- a/src/Web/FakeHttpRequest.cs
+++ b/src/Web/FakeHttpRequest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Web;
 
@@ -22,6 +21,7 @@ namespace FakeN.Web
 		private string applicationPath;
 		private string[] acceptTypes;
 		private Stream inputStream;
+		private bool isAuthenticated;
 
 		public FakeHttpRequest(Uri url = null, string method = "GET")
 		{
@@ -33,6 +33,16 @@ namespace FakeN.Web
 			headers = new NameValueCollection();
 			serverVariables = new NameValueCollection();
 			cookies = new HttpCookieCollection();
+		}
+
+		public void SetAuthenticated(bool authenticated) 
+		{
+			isAuthenticated = authenticated;
+		}
+
+		public override bool IsAuthenticated 
+		{
+			get { return isAuthenticated; }
 		}
 
 		public override Uri Url

--- a/test/Web/RequestTests.cs
+++ b/test/Web/RequestTests.cs
@@ -90,5 +90,15 @@ namespace FakeN.Web.Test
 			var rdr = new StreamReader(gotStream, Encoding.UTF8);
 			Assert.That(rdr.ReadToEnd(), Is.EqualTo(requestBodyText));
 		}
+
+		[Test]
+		public void Can_set_authenticated_status() 
+		{
+			var request = new FakeHttpRequest();
+
+			Assert.That(request, Has.Property("IsAuthenticated").False);
+			request.SetAuthenticated(true);
+			Assert.That(request, Has.Property("IsAuthenticated").True);
+		}
 	}
 }

--- a/test/Web/UserTests.cs
+++ b/test/Web/UserTests.cs
@@ -25,6 +25,7 @@ namespace FakeN.Web.Test
 			var context = new FakeHttpContext().Authenticate();
 
 			Assert.That(context.User.Identity.IsAuthenticated, Is.True);
+			Assert.That(context.Request.IsAuthenticated, Is.True);
 		}
 
 		[Test]


### PR DESCRIPTION
``` c#
var request = new FakeHttpRequest();
Console.WriteLine(request.IsAuthenticated); //False: previously a NotImplementedException
request.SetAuthenticated(true);
Console.WriteLine(request.IsAuthenticated); //True
```

Also extended the `FakeHttpContext.Authenticate()` extension method:

``` c#
var context = new FakeHttpContext();
context.Authenticate();
Console.WriteLine(context.Request.IsAuthenticated); //True
```
