### PR TITLE
Use some fancy expression tree magic to make all virtual properties settable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -71,7 +71,7 @@ public void Should_add_values_to_session()
 
 User:
 
-```
+```c#
 [Test]
 public void User_should_not_be_authenticated()
 {

--- a/README.markdown
+++ b/README.markdown
@@ -90,3 +90,19 @@ public void User_can_be_authenticated_with_convenience_method()
 }
 ```
 
+You can also set any virtual property from one of the `Http*` classes, even those that aren't explicitly settable. e.g., for `HttpContext`:
+
+```c#
+var context = new FakeHttpContext();
+var uri = new Uri("http://www.google.com/");
+
+//set the UrlReferrer
+context.Set(ctx => ctx.UrlReferrer, uri);
+
+//get the UrlReferrer
+Console.WriteLine(context.UrlReferrer); //<http://www.google.com/>
+```
+
+This means no more `NotImplementedException`s in your tests.
+
+

--- a/README.markdown
+++ b/README.markdown
@@ -86,6 +86,7 @@ public void User_can_be_authenticated_with_convenience_method()
 	var context = new FakeHttpContext().Authenticate();
 
 	Assert.That(context.User.Identity.IsAuthenticated, Is.True);
+	Assert.That(context.Request.IsAuthenticated, Is.True);
 }
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -20,63 +20,72 @@ Examples:
 
 QueryString:
 
-	[Test]
-	public void Url_query_string_should_add_to_query_string_collection()
-	{
-		var url = new Uri("http://google.com?q=awesome&p=1");
+```c#
+[Test]
+public void Url_query_string_should_add_to_query_string_collection()
+{
+	var url = new Uri("http://google.com?q=awesome&p=1");
 
-		var request = new FakeHttpRequest(url);
+	var request = new FakeHttpRequest(url);
 
-		Assert.That(request.QueryString["q"], Is.EqualTo("awesome"));
-		Assert.That(request.QueryString["p"], Is.EqualTo("1"));
-	}
+	Assert.That(request.QueryString["q"], Is.EqualTo("awesome"));
+	Assert.That(request.QueryString["p"], Is.EqualTo("1"));
+}
 
-	[Test]
-	public void Can_access_query_string_values_by_default_indexer()
-	{
-		var request = new FakeHttpRequest();
+[Test]
+public void Can_access_query_string_values_by_default_indexer()
+{
+	var request = new FakeHttpRequest();
 
-		request.QueryString.Add("id", "3");
+	request.QueryString.Add("id", "3");
 
-		Assert.That(request["id"], Is.EqualTo("3"));
-	}
+	Assert.That(request["id"], Is.EqualTo("3"));
+}
+```
 
 Form:
 
-	[Test]
-	public void Can_access_form_values_by_default_indexer()
-	{
-		var request = new FakeHttpRequest();
+```c#
+[Test]
+public void Can_access_form_values_by_default_indexer()
+{
+	var request = new FakeHttpRequest();
 
-		request.Form.Add("color", "blue");
+	request.Form.Add("color", "blue");
 
-		Assert.That(request["color"], Is.EqualTo("blue"));
-	}
+	Assert.That(request["color"], Is.EqualTo("blue"));
+}
+```
 
 Session:
 
-	[Test]
-	public void Should_add_values_to_session()
-	{
-		var session = new FakeHttpSessionState { { "color", "red" } };
+```c#
+[Test]
+public void Should_add_values_to_session()
+{
+	var session = new FakeHttpSessionState { { "color", "red" } };
 
-		Assert.That(session["color"], Is.EqualTo("red"));
-	}
+	Assert.That(session["color"], Is.EqualTo("red"));
+}
+```
 
 User:
 
-	[Test]
-	public void User_should_not_be_authenticated()
-	{
-		var principal = new FakeHttpContext().User;
+```
+[Test]
+public void User_should_not_be_authenticated()
+{
+	var principal = new FakeHttpContext().User;
 
-		Assert.That(principal.Identity.IsAuthenticated, Is.False);
-	}
+	Assert.That(principal.Identity.IsAuthenticated, Is.False);
+}
 
-	[Test]
-	public void User_can_be_authenticated_with_convenience_method()
-	{
-		var context = new FakeHttpContext().Authenticate();
+[Test]
+public void User_can_be_authenticated_with_convenience_method()
+{
+	var context = new FakeHttpContext().Authenticate();
 
-		Assert.That(context.User.Identity.IsAuthenticated, Is.True);
-	}
+	Assert.That(context.User.Identity.IsAuthenticated, Is.True);
+}
+```
+

--- a/src/Web/FakeHttpCachePolicy.cs
+++ b/src/Web/FakeHttpCachePolicy.cs
@@ -4,6 +4,10 @@ namespace FakeN.Web
 {
 	public class FakeHttpCachePolicy : HttpCachePolicyBase
 	{
+		private HttpCacheVaryByParams varyByParams;
+		private HttpCacheVaryByHeaders varyByHeaders;
+		private HttpCacheVaryByContentEncodings varyByContentEncodings;
+
 		public override void SetExpires(System.DateTime date)
 		{
 		}
@@ -23,5 +27,9 @@ namespace FakeN.Web
 		public override void SetNoStore()
 		{
 		}
+
+		public override HttpCacheVaryByParams VaryByParams { get { return varyByParams; } }
+		public override HttpCacheVaryByHeaders VaryByHeaders { get { return varyByHeaders; } }
+		public override HttpCacheVaryByContentEncodings VaryByContentEncodings { get { return varyByContentEncodings; } }
 	}
 }

--- a/src/Web/FakeHttpContext.cs
+++ b/src/Web/FakeHttpContext.cs
@@ -3,6 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Security.Principal;
 using System.Web;
+using System.Web.Caching;
+using System.Web.Profile;
 
 namespace FakeN.Web
 {
@@ -12,6 +14,24 @@ namespace FakeN.Web
 		private readonly HttpResponseBase response;
 		private readonly HttpSessionStateBase session;
 		private readonly IDictionary items;
+
+		private TraceContext trace;
+		private DateTime timestamp;
+		private bool skipAuthorization;
+		private HttpServerUtilityBase server;
+		private ProfileBase profile;
+		private IHttpHandler previousHandler;
+		private bool isPostNotification;
+		private bool isDebuggingEnabled;
+		private bool isCustomErrorEnabled;
+		private IHttpHandler handler;
+		private Exception error;
+		private RequestNotification currentNotification;
+		private IHttpHandler currentHandler;
+		private Cache cache;
+		private HttpApplication applicationInstance;
+		private HttpApplicationStateBase application;
+		private Exception[] allErrors;
 
 		public FakeHttpContext(
 			HttpRequestBase request = null,
@@ -46,5 +66,23 @@ namespace FakeN.Web
 		}
 
 		public override IPrincipal User { get; set; }
+
+		public override TraceContext Trace { get { return trace; } }
+		public override DateTime Timestamp { get { return timestamp; } }
+		public override bool SkipAuthorization { get { return skipAuthorization; } set { skipAuthorization = value; } }
+		public override HttpServerUtilityBase Server { get { return server; } }
+		public override ProfileBase Profile { get { return profile; } }
+		public override IHttpHandler PreviousHandler { get { return previousHandler; } }
+		public override bool IsPostNotification { get { return isPostNotification; } }
+		public override bool IsDebuggingEnabled { get { return isDebuggingEnabled; } }
+		public override bool IsCustomErrorEnabled { get { return isCustomErrorEnabled; } }
+		public override IHttpHandler Handler { get { return handler; } set { handler = value; } }
+		public override Exception Error { get { return error; } }
+		public override RequestNotification CurrentNotification { get { return currentNotification; } }
+		public override IHttpHandler CurrentHandler { get { return currentHandler; } }
+		public override Cache Cache { get { return cache; } }
+		public override HttpApplication ApplicationInstance { get { return applicationInstance; } set { applicationInstance = value; } }
+		public override HttpApplicationStateBase Application { get { return application; } }
+		public override Exception[] AllErrors { get { return allErrors; } }
 	}
 }

--- a/src/Web/FakeHttpContextExtensions.cs
+++ b/src/Web/FakeHttpContextExtensions.cs
@@ -19,6 +19,11 @@ namespace FakeN.Web
 
 		public static FakeHttpContext Authenticate(this FakeHttpContext context)
 		{
+			var request = context.Request as FakeHttpRequest;
+			if (request != null) {
+				request.SetAuthenticated(true);
+			}
+
 			return context.Set(new MutableIdentity { IsAuthenticated = true });
 		}
 

--- a/src/Web/FakeHttpContextExtensions.cs
+++ b/src/Web/FakeHttpContextExtensions.cs
@@ -21,7 +21,7 @@ namespace FakeN.Web
 		{
 			var request = context.Request as FakeHttpRequest;
 			if (request != null) {
-				request.SetAuthenticated(true);
+				request.Set(req => req.IsAuthenticated, true);
 			}
 
 			return context.Set(new MutableIdentity { IsAuthenticated = true });

--- a/src/Web/FakeHttpRequest.cs
+++ b/src/Web/FakeHttpRequest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Web;
 
@@ -22,6 +21,7 @@ namespace FakeN.Web
 		private string applicationPath;
 		private string[] acceptTypes;
 		private Stream inputStream;
+		private bool isAuthenticated;
 
 		public FakeHttpRequest(Uri url = null, string method = "GET")
 		{
@@ -33,6 +33,16 @@ namespace FakeN.Web
 			headers = new NameValueCollection();
 			serverVariables = new NameValueCollection();
 			cookies = new HttpCookieCollection();
+		}
+
+		public void SetAuthenticated(bool authenticated) 
+		{
+			isAuthenticated = authenticated;
+		}
+
+		public override bool IsAuthenticated 
+		{
+			get { return isAuthenticated; }
 		}
 
 		public override Uri Url

--- a/src/Web/FakeHttpRequest.cs
+++ b/src/Web/FakeHttpRequest.cs
@@ -1,13 +1,18 @@
 ﻿using System;
 using System.Collections.Specialized;
+using System.Dynamic;
 using System.IO;
+using System.Security.Authentication.ExtendedProtection;
+using System.Security.Principal;
 using System.Text;
 using System.Web;
+using System.Web.Routing;
 
-namespace FakeN.Web
-{
-	public class FakeHttpRequest : HttpRequestBase
-	{
+namespace FakeN.Web {
+
+	public interface IHttpObject { }
+
+	public class FakeHttpRequest : HttpRequestBase, IHttpObject {
 		private readonly NameValueCollection form;
 		private readonly NameValueCollection queryString;
 		private readonly NameValueCollection headers;
@@ -23,8 +28,32 @@ namespace FakeN.Web
 		private Stream inputStream;
 		private bool isAuthenticated;
 
-		public FakeHttpRequest(Uri url = null, string method = "GET")
-		{
+		private string anonymousId;
+		private string appRelativeCurrentExecutionFilePath;
+		private HttpBrowserCapabilitiesBase browser;
+		private ChannelBinding httpChannelBinding;
+		private HttpClientCertificate clientCertificate;
+		private int contentLength;
+		private string currentExecutionFilePath;
+		private Stream filter;
+		private bool isSecureConnection;
+		private WindowsIdentity logonUserIdentity;
+		private NameValueCollection @params;
+		private string physicalApplicationPath;
+		private string physicalPath;
+		private RequestContext requestContext;
+		private int totalBytes;
+		private Uri urlReferrer;
+		private string userAgent;
+		private string[] userLanguages;
+		private string userHostName;
+		private string pathInfo;
+
+		private static NameValueCollection ParseQueryString(string url) {
+			return HttpUtility.ParseQueryString(url);
+		}
+
+		public FakeHttpRequest(Uri url = null, string method = "GET") {
 			this.url = url ?? new Uri("http://localhost");
 			this.method = method;
 			acceptTypes = new string[] { };
@@ -35,167 +64,57 @@ namespace FakeN.Web
 			cookies = new HttpCookieCollection();
 		}
 
-		public void SetAuthenticated(bool authenticated) 
-		{
-			isAuthenticated = authenticated;
-		}
-
-		public override bool IsAuthenticated 
-		{
-			get { return isAuthenticated; }
-		}
-
-		public override Uri Url
-		{
-			get { return url; }
-		}
-
-		public FakeHttpRequest SetUrl(Uri url)
-		{
+		public FakeHttpRequest SetUrl(Uri url) {
 			this.url = url;
 			queryString.Clear();
 			queryString.Add(ParseQueryString(url.Query));
 			return this;
 		}
 
-		public override bool IsLocal
-		{
-			get { return isLocal; }
-		}
-
-		public FakeHttpRequest SetIsLocal(bool isLocal)
-		{
-			this.isLocal = isLocal;
-			return this;
-		}
-
-		public override string ApplicationPath
-		{
-			get { return applicationPath; }
-		}
-
-		public FakeHttpRequest SetApplicationPath(string applicationPath)
-		{
-			this.applicationPath = applicationPath;
-			return this;
-		}
-
-		public override string HttpMethod
-		{
-			get { return method; }
-		}
-
-		public FakeHttpRequest SetHttpMethod(string method)
-		{
-			this.method = method;
-			return this;
-		}
-
-		public override string UserHostAddress
-		{
-			get { return userHostAddress; }
-		}
-
-		public FakeHttpRequest SetUserHostAddress(string userHostAddress)
-		{
-			this.userHostAddress = userHostAddress;
-			return this;
-		}
-
-		public override string[] AcceptTypes
-		{
-			get { return acceptTypes; }
-		}
-
-		public FakeHttpRequest SetAcceptTypes(string[] acceptTypes)
-		{
-			this.acceptTypes = acceptTypes;
-			return this;
-		}
-
-		public override string RequestType { get; set; }
-
-		public override string ContentType { get; set; }
-
-		public override Encoding ContentEncoding { get; set; }
-
-		public override void ValidateInput() { }
-
-		public override string RawUrl
-		{
-			get { return url.PathAndQuery; }
-		}
-
-		public override string this[string key]
-		{
+		public override string this[string key] {
 			get { return new NameValueCollection { form, queryString }[key]; }
 		}
 
-		public override NameValueCollection Form
-		{
-			get { return form; }
-		}
-
-		public override NameValueCollection QueryString
-		{
-			get { return queryString; }
-		}
-
-		public override NameValueCollection Headers
-		{
-			get { return headers; }
-		}
-
-		public override NameValueCollection ServerVariables
-		{
-			get { return serverVariables; }
-		}
-
-		public override HttpCookieCollection Cookies
-		{
-			get { return cookies; }
-		}
-
-		static NameValueCollection ParseQueryString(string url)
-		{
-			return HttpUtility.ParseQueryString(url);
-		}
-
-		public override HttpFileCollectionBase Files
-		{
-			get { return files; }
-		}
-
-		public void SetFiles(FakeHttpFileCollection files)
-		{
-			this.files = files;
-		}
-
-		public override string Path
-		{
-			get { return Url.AbsolutePath; }
-		}
-
-		public override string FilePath
-		{
-			//TODO: in the case that the handler would be mapped to a prefix of the path, the last part of the AbsolutePath would be returned in PathInfo
-			get { return Url.AbsolutePath; }
-		}
-
-		public override string PathInfo
-		{
-			//TODO: in the case that the handler would be mapped to a prefix of the path, the last part of the AbsolutePath would be returned in PathInfo
-			get { throw new NotImplementedException(); }
-		}
-
-		public override Stream InputStream
-		{
-			get { return inputStream; }
-		}
-
-		public void SetInputStream(Stream inputStream)
-		{
-			this.inputStream = inputStream;
-		}
+		public override bool IsAuthenticated { get { return isAuthenticated; } }
+		public override Uri Url { get { return url; } }
+		public override bool IsLocal { get { return isLocal; } }
+		public override string ApplicationPath { get { return applicationPath; } }
+		public override string HttpMethod { get { return method; } }
+		public override string UserHostAddress { get { return userHostAddress; } }
+		public override string[] AcceptTypes { get { return acceptTypes; } }
+		public override string RequestType { get; set; }
+		public override string ContentType { get; set; }
+		public override Encoding ContentEncoding { get; set; }
+		public override void ValidateInput() { }
+		public override string RawUrl { get { return url.PathAndQuery; } }
+		public override NameValueCollection Form { get { return form; } }
+		public override NameValueCollection QueryString { get { return queryString; } }
+		public override NameValueCollection Headers { get { return headers; } }
+		public override NameValueCollection ServerVariables { get { return serverVariables; } }
+		public override HttpCookieCollection Cookies { get { return cookies; } }
+		public override HttpFileCollectionBase Files { get { return files; } }
+		public override string Path { get { return Url.AbsolutePath; } }
+		public override string FilePath { get { return Url.AbsolutePath; } }
+		public override string PathInfo { get { return pathInfo; } }
+		public override Stream InputStream { get { return inputStream; } }
+		public override string AnonymousID { get { return anonymousId; } }
+		public override string AppRelativeCurrentExecutionFilePath { get { return appRelativeCurrentExecutionFilePath; } }
+		public override HttpBrowserCapabilitiesBase Browser { get { return browser; } }
+		public override ChannelBinding HttpChannelBinding { get { return httpChannelBinding; } }
+		public override HttpClientCertificate ClientCertificate { get { return clientCertificate; } }
+		public override int ContentLength { get { return contentLength; } }
+		public override string CurrentExecutionFilePath { get { return currentExecutionFilePath; } }
+		public override Stream Filter { get { return filter; } set { filter = value; } }
+		public override bool IsSecureConnection { get { return isSecureConnection; } }
+		public override WindowsIdentity LogonUserIdentity { get { return logonUserIdentity; } }
+		public override NameValueCollection Params { get { return @params; } }
+		public override string PhysicalApplicationPath { get { return physicalApplicationPath; } }
+		public override string PhysicalPath { get { return physicalPath; } }
+		public override RequestContext RequestContext { get { return requestContext; } }
+		public override int TotalBytes { get { return totalBytes; } }
+		public override Uri UrlReferrer { get { return urlReferrer; } }
+		public override string UserAgent { get { return userAgent; } }
+		public override string[] UserLanguages { get { return userLanguages; } }
+		public override string UserHostName { get { return userHostName; } }
 	}
 }

--- a/src/Web/FakeHttpResponse.cs
+++ b/src/Web/FakeHttpResponse.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Specialized;
+using System.IO;
+using System.Text;
 using System.Web;
 
 namespace FakeN.Web
@@ -6,6 +9,46 @@ namespace FakeN.Web
 	public class FakeHttpResponse : HttpResponseBase
 	{
 		private Func<string, string> appPathModifier;
+
+		private bool buffer;
+
+		private bool bufferOutput;
+
+		private string cacheControl;
+
+		private string charset;
+
+		private Encoding contentEncoding;
+
+		private string contentType;
+
+		private HttpCookieCollection cookies;
+
+		private int expires;
+
+		private DateTime expiresAbsolute;
+
+		private Stream filter;
+
+		private NameValueCollection headers;
+
+		private Encoding headerEncoding;
+
+		private bool isClientConnected;
+
+		private bool isRequestBeingRedirected;
+
+		private TextWriter output;
+
+		private Stream outputStream;
+
+		private string redirectLocation;
+
+		private string status;
+
+		private bool suppressContent;
+
+		private bool trySkipIisCustomErrors;
 
 		public FakeHttpResponse()
 		{
@@ -31,5 +74,26 @@ namespace FakeN.Web
 		public override int StatusCode { get; set; }
 		public override string StatusDescription { get; set; }
 		public override int SubStatusCode { get; set; }
+
+		public override bool Buffer { get { return buffer; } set { buffer = value; } }
+		public override bool BufferOutput { get { return bufferOutput; } set { bufferOutput = value; } }
+		public override string CacheControl { get { return cacheControl; } set { cacheControl = value; } }
+		public override string Charset { get { return charset; } set { charset = value; } }
+		public override Encoding ContentEncoding { get { return contentEncoding; } set { contentEncoding = value; } }
+		public override string ContentType { get { return contentType; } set { contentType = value; } }
+		public override HttpCookieCollection Cookies { get { return cookies; } }
+		public override int Expires { get { return expires; } set { expires = value; } }
+		public override DateTime ExpiresAbsolute { get { return expiresAbsolute; } set { expiresAbsolute = value; } }
+		public override Stream Filter { get { return filter; } set { filter = value; } }
+		public override NameValueCollection Headers { get { return headers; } }
+		public override Encoding HeaderEncoding { get { return headerEncoding; } set { headerEncoding = value; } }
+		public override bool IsClientConnected { get { return isClientConnected; } }
+		public override bool IsRequestBeingRedirected { get { return isRequestBeingRedirected; } }
+		public override TextWriter Output { get { return output; } set { output = value; } }
+		public override Stream OutputStream { get { return outputStream; } }
+		public override string RedirectLocation { get { return redirectLocation; } set { redirectLocation = value; } }
+		public override string Status { get { return status; } set { status = value; } }
+		public override bool SuppressContent { get { return suppressContent; } set { suppressContent = value; } }
+		public override bool TrySkipIisCustomErrors { get { return trySkipIisCustomErrors; } set { trySkipIisCustomErrors = value; } }
 	}
 }

--- a/src/Web/FakeHttpSessionState.cs
+++ b/src/Web/FakeHttpSessionState.cs
@@ -1,11 +1,26 @@
 ﻿using System.Collections.Specialized;
 using System.Web;
+using System.Web.SessionState;
 
 namespace FakeN.Web
 {
 	public class FakeHttpSessionState : HttpSessionStateBase
 	{
 		private readonly SessionStateCollection data;
+		private int codePage;
+		private HttpSessionStateBase contents;
+		private HttpCookieMode cookieMode;
+		private bool isCookieless;
+		private bool isNewSession;
+		private bool isReadOnly;
+		private int lcid;
+		private SessionStateMode mode;
+		private string sessionId;
+		private HttpStaticObjectsCollectionBase staticObjects;
+		private int timeout;
+		private int count;
+		private bool isSynchronized;
+		private object syncRoot;
 
 		public FakeHttpSessionState()
 		{
@@ -36,5 +51,20 @@ namespace FakeN.Web
 				set { BaseSet(key, value); }
 			}
 		}
+
+		public override int CodePage { get { return codePage; } set { codePage = value; } }
+		public override HttpSessionStateBase Contents { get { return contents; } }
+		public override HttpCookieMode CookieMode { get { return cookieMode; } }
+		public override bool IsCookieless { get { return isCookieless; } }
+		public override bool IsNewSession { get { return isNewSession; } }
+		public override bool IsReadOnly { get { return isReadOnly; } }
+		public override int LCID { get { return lcid; } set { lcid = value; } }
+		public override SessionStateMode Mode { get { return mode; } }
+		public override string SessionID { get { return sessionId; } }
+		public override HttpStaticObjectsCollectionBase StaticObjects { get { return staticObjects; } }
+		public override int Timeout { get { return timeout; } set { timeout = value; } }
+		public override int Count { get { return count; } }
+		public override bool IsSynchronized { get { return isSynchronized; } }
+		public override object SyncRoot { get { return syncRoot; } }
 	}
 }

--- a/src/Web/FakeN.Web.csproj
+++ b/src/Web/FakeN.Web.csproj
@@ -50,6 +50,7 @@
     <Compile Include="FakeHttpResponse.cs" />
     <Compile Include="FakeHttpSessionState.cs" />
     <Compile Include="FakeHttpSessionStateExtensions.cs" />
+    <Compile Include="HttpObjectExtensions.cs" />
     <Compile Include="MutableIdentity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Web/HttpObjectExtensions.cs
+++ b/src/Web/HttpObjectExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace FakeN.Web {
+	public static class HttpObjectExtensions {
+		public static FakeHttpResponse Set<T>(this FakeHttpResponse res, Expression<Func<FakeHttpResponse, T>> getterExpression, T value) {
+			res.Set<FakeHttpResponse, T>(getterExpression, value);
+			return res;
+		}
+
+		public static FakeHttpRequest Set<T>(this FakeHttpRequest req, Expression<Func<FakeHttpRequest, T>> getterExpression, T value) {
+			req.Set<FakeHttpRequest, T>(getterExpression, value);
+			return req;
+		}
+
+		public static FakeHttpSessionState Set<T>(this FakeHttpSessionState session, Expression<Func<FakeHttpSessionState, T>> getterExpression, T value) {
+			session.Set<FakeHttpSessionState, T>(getterExpression, value);
+			return session;
+		}
+
+		public static FakeHttpContext Set<T>(this FakeHttpContext context, Expression<Func<FakeHttpContext, T>> getterExpression, T value) {
+			context.Set<FakeHttpContext, T>(getterExpression, value);
+			return context;
+		}
+
+		public static FakeHttpCachePolicy Set<T>(this FakeHttpCachePolicy cache, Expression<Func<FakeHttpCachePolicy, T>> getterExpression, T value) {
+			cache.Set<FakeHttpCachePolicy, T>(getterExpression, value);
+			return cache;
+		}
+
+		private static void Set<T, TValue>(this T req, Expression<Func<T, TValue>> getterExpression, TValue value) {
+			var body = getterExpression.Body as MemberExpression;
+			if (body == null) {
+				throw new ArgumentException("Expression is not a get accessor", "getterExpression");
+			}
+
+			var member = body.Member;
+
+			//call set method if it exists
+			var setMethod = req.GetType().GetMethod("Set" + member.Name, new[] { typeof(T) });
+			if (setMethod != null) {
+				setMethod.Invoke(req, new object[] { value });
+				return;
+			}
+
+			//otherwise fall back to private backing field
+			var backingField = member.Name.Substring(0, 1).ToLower() + member.Name.Substring(1);
+			var field = req.GetType().GetField(backingField, BindingFlags.Instance | BindingFlags.NonPublic);
+			if (field == null) {
+				throw new Exception(string.Format("The backing field {0} for {1} doesn't exist", backingField, member.Name));
+			}
+
+			field.SetValue(req, value);
+		}
+	}
+}

--- a/test/Web/RequestTests.cs
+++ b/test/Web/RequestTests.cs
@@ -90,5 +90,15 @@ namespace FakeN.Web.Test
 			var rdr = new StreamReader(gotStream, Encoding.UTF8);
 			Assert.That(rdr.ReadToEnd(), Is.EqualTo(requestBodyText));
 		}
+
+		[Test]
+		public void Can_set_authenticated_status() 
+		{
+			var request = new FakeHttpRequest();
+
+			Assert.That(request, Has.Property("IsAuthenticated").False);
+			request.SetAuthenticated(true);
+			Assert.That(request, Has.Property("IsAuthenticated").True);
+		}
 	}
 }

--- a/test/Web/RequestTests.cs
+++ b/test/Web/RequestTests.cs
@@ -33,7 +33,7 @@ namespace FakeN.Web.Test
 		[Test]
 		public void Request_can_be_specified_to_be_local()
 		{
-			Assert.That(new FakeHttpRequest().SetIsLocal(true).IsLocal, Is.True);
+			Assert.That(new FakeHttpRequest().Set(req => req.IsLocal, true).IsLocal, Is.True);
 		}
 
 		[Test]
@@ -69,7 +69,7 @@ namespace FakeN.Web.Test
 
 			var file = new FakeHttpPostedFile("SomeFile.txt", "text/plain", fileContents);
 			files.Add("FileFormFieldValue", file);
-			request.SetFiles(files);
+			request.Set(req => req.Files, files);
 
 			Assert.That(request.Files.Count, Is.EqualTo(1));
 			Assert.That(request.Files[0].FileName, Is.EqualTo("SomeFile.txt"));
@@ -84,7 +84,7 @@ namespace FakeN.Web.Test
 			var requestBodyText = "This is the raw request body.";
 			var bytes = Encoding.UTF8.GetBytes(requestBodyText);
 			var stream = new MemoryStream(bytes, false);
-			request.SetInputStream(stream);
+			request.Set(req => req.InputStream, stream);
 
 			var gotStream = request.InputStream;
 			var rdr = new StreamReader(gotStream, Encoding.UTF8);
@@ -97,8 +97,16 @@ namespace FakeN.Web.Test
 			var request = new FakeHttpRequest();
 
 			Assert.That(request, Has.Property("IsAuthenticated").False);
-			request.SetAuthenticated(true);
+			request.Set(req => req.IsAuthenticated, true);
 			Assert.That(request, Has.Property("IsAuthenticated").True);
+		}
+
+		[Test]
+		public void Should_set_value() {
+			var request = new FakeHttpRequest();
+			var uri = new Uri("http://localhost/");
+			request.Set(req => req.UrlReferrer, uri);
+			Assert.That(request, Has.Property("UrlReferrer").EqualTo(uri));
 		}
 	}
 }

--- a/test/Web/UserTests.cs
+++ b/test/Web/UserTests.cs
@@ -25,6 +25,7 @@ namespace FakeN.Web.Test
 			var context = new FakeHttpContext().Authenticate();
 
 			Assert.That(context.User.Identity.IsAuthenticated, Is.True);
+			Assert.That(context.Request.IsAuthenticated, Is.True);
 		}
 
 		[Test]


### PR DESCRIPTION
No more `NotImplementedException`s being thrown. ALL virtual properties are overridden, are are settable via the `Set<T>()` extension method for `FakeHttpContext`, `FakeHttpResponse`, `FakeHttpRequest`, `FakeHttpCachePolicy` and `FakeHttpSessionState`.

Example:

``` c#
var context = new FakeHttpContext();
context.IsAuthenticated = true; //compile time error, no setter
context.Set(ctx => ctx.IsAuthenticated, true);
Console.WriteLine(context.IsAuthenticated); //True
```
