### PR TITLE
Removed some NullReferenceException, added an alternative way of configuring the objects and added fluent configurators.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -90,17 +90,38 @@ public void User_can_be_authenticated_with_convenience_method()
 }
 ```
 
-You can also set any virtual property from one of the `Http*` classes, even those that aren't explicitly settable. e.g., for `HttpContext`:
+All properties for the Request/HttpContext/Response can be set using the `Control` property, even those that normally are read only.
 
 ```c#
-var context = new FakeHttpContext();
+var request = new FakeHttpRequest();
 var uri = new Uri("http://www.google.com/");
 
 //set the UrlReferrer
-context.Set(ctx => ctx.UrlReferrer, uri);
+request.Control.UrlReferrer = uri;
 
 //get the UrlReferrer
-Console.WriteLine(context.UrlReferrer); //<http://www.google.com/>
+Console.WriteLine(request.UrlReferrer); //<http://www.google.com/>
+```
+
+You can also use our fluent builders:
+
+```csharp
+// simple context
+var httpContext = builder
+    .Post("http://localhost/?A=1")
+    .RespondWith(new {Status = "Ok"})
+    .Build();
+
+// configuring the session
+var httpContext = builder
+    .UsingSession(new {UserId = 10})
+    .Build();
+
+// setting principal
+var principal ? new GenericPrincipal(new GenericIdentity("Arne"), new []{"Admin"});
+var httpContext = builder
+    .UsePrincipal(principal)
+    .Build();
 ```
 
 This means no more `NotImplementedException`s in your tests.

--- a/README.markdown
+++ b/README.markdown
@@ -109,7 +109,8 @@ You can also use our fluent builders:
 // simple context
 var httpContext = builder
     .Post("http://localhost/?A=1")
-    .RespondWith(new {Status = "Ok"})
+    .WithForm(new { FirstName = "Jonas", LastName = "Gauffin", UserName = "jgauffin" })
+    .RespondWith(403)
     .Build();
 
 // configuring the session

--- a/src/Web/FakeHttpApplication.cs
+++ b/src/Web/FakeHttpApplication.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Web;
+
+namespace FakeN.Web
+{
+    public class FakeHttpApplication : HttpApplication
+    {
+        /// <summary>
+        ///     Used to override <c>GetOutputCacheProviderName</c>
+        /// </summary>
+        public Func<HttpContext, string> GetOutputCacheProviderNameCallback;
+
+        /// <summary>
+        ///     Used to ovveride <c>GetVaryByCustomString</c>.
+        /// </summary>
+        public Func<HttpContext, string, string> GetVaryByCustomStringCallback;
+
+        public FakeHttpApplication(HttpApplication assignedApplication)
+        {
+            AssignedApplication = assignedApplication;
+        }
+
+        public FakeHttpApplication()
+
+        {
+        }
+
+        public HttpApplication AssignedApplication { get; set; }
+
+        /// <summary>
+        ///     Gets the name of the default output-cache provider that is configured for a Web site.
+        /// </summary>
+        /// <returns>
+        ///     The name of the default provider.
+        /// </returns>
+        /// <param name="context">
+        ///     An <see cref="T:System.Web.HttpContext" /> that provides references to intrinsic server objects
+        ///     that are used to service HTTP requests.
+        /// </param>
+        /// <exception cref="T:System.Configuration.Provider.ProviderException">
+        ///     <paramref name="context" /> is null or is an empty
+        ///     string.
+        /// </exception>
+        public override string GetOutputCacheProviderName(HttpContext context)
+        {
+            if (GetOutputCacheProviderNameCallback != null)
+                return GetOutputCacheProviderNameCallback(context);
+
+            return base.GetOutputCacheProviderName(context);
+        }
+
+        /// <summary>
+        ///     Provides an application-wide implementation of the
+        ///     <see cref="P:System.Web.UI.PartialCachingAttribute.VaryByCustom" /> property.
+        /// </summary>
+        /// <returns>
+        ///     If the value of the <paramref name="custom" /> parameter is "browser", the browser's
+        ///     <see cref="P:System.Web.Configuration.HttpCapabilitiesBase.Type" />; otherwise, null.
+        /// </returns>
+        /// <param name="context">
+        ///     An <see cref="T:System.Web.HttpContext" /> object that contains information about the current Web
+        ///     request.
+        /// </param>
+        /// <param name="custom">The custom string that specifies which cached response is used to respond to the current request. </param>
+        public override string GetVaryByCustomString(HttpContext context, string custom)
+        {
+            if (GetVaryByCustomStringCallback != null)
+                return GetVaryByCustomStringCallback(context, custom);
+
+            return base.GetVaryByCustomString(context, custom);
+        }
+    }
+}

--- a/src/Web/FakeHttpContext.cs
+++ b/src/Web/FakeHttpContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Security.Principal;
 using System.Web;
 using System.Web.Caching;
@@ -8,81 +7,146 @@ using System.Web.Profile;
 
 namespace FakeN.Web
 {
-	public class FakeHttpContext : HttpContextBase
-	{
-		private readonly HttpRequestBase request;
-		private readonly HttpResponseBase response;
-		private readonly HttpSessionStateBase session;
-		private readonly IDictionary items;
+    public class FakeHttpContext : HttpContextBase
+    {
+        private readonly ProfileBase _profile;
+        private readonly HttpRequestBase request;
+        private readonly HttpResponseBase response;
+        private readonly HttpSessionStateBase session;
 
-		private TraceContext trace;
-		private DateTime timestamp;
-		private bool skipAuthorization;
-		private HttpServerUtilityBase server;
-		private ProfileBase profile;
-		private IHttpHandler previousHandler;
-		private bool isPostNotification;
-		private bool isDebuggingEnabled;
-		private bool isCustomErrorEnabled;
-		private IHttpHandler handler;
-		private Exception error;
-		private RequestNotification currentNotification;
-		private IHttpHandler currentHandler;
-		private Cache cache;
-		private HttpApplication applicationInstance;
-		private HttpApplicationStateBase application;
-		private Exception[] allErrors;
+        public FakeHttpContext(
+            HttpRequestBase request = null,
+            HttpResponseBase response = null,
+            HttpSessionStateBase session = null)
+        {
+            this.request = request;
+            this.response = response;
+            this.session = session;
+            _profile = new ProfileBase();
+            Control = new FakeHttpContextControl(this);
+        }
 
-		public FakeHttpContext(
-			HttpRequestBase request = null,
-			HttpResponseBase response = null,
-			HttpSessionStateBase session = null)
-		{
-			this.request = request ?? new FakeHttpRequest();
-			this.response = response ?? new FakeHttpResponse();
-			this.session = session ?? new FakeHttpSessionState();
-			items = new Dictionary<object, object>();
-			User = new GenericPrincipal(new MutableIdentity(), new string[] { });
-		}
+        public FakeHttpContext(FakeHttpContextControl control)
+        {
+            Control = control;
+            _profile = new ProfileBase();
+        }
 
-		public override HttpRequestBase Request
-		{
-			get { return request; }
-		}
+        public FakeHttpContext()
+        {
+            Control = new FakeHttpContextControl();
+            _profile = new ProfileBase();
+        }
 
-		public override HttpResponseBase Response
-		{
-			get { return response; }
-		}
+        /// <summary>
+        ///     Used to control this context.
+        /// </summary>
+        public FakeHttpContextControl Control { get; private set; }
 
-		public override HttpSessionStateBase Session
-		{
-			get { return session; }
-		}
+        public override HttpRequestBase Request
+        {
+            get { return request ?? Control.Request; }
+        }
 
-		public override IDictionary Items
-		{
-			get { return items; }
-		}
+        public override HttpResponseBase Response
+        {
+            get { return response ?? Control.Response; }
+        }
 
-		public override IPrincipal User { get; set; }
+        public override HttpSessionStateBase Session
+        {
+            get { return session ?? Control.Session; }
+        }
+        
+        public override IDictionary Items
+        {
+            get { return Control.Items; }
+        }
 
-		public override TraceContext Trace { get { return trace; } }
-		public override DateTime Timestamp { get { return timestamp; } }
-		public override bool SkipAuthorization { get { return skipAuthorization; } set { skipAuthorization = value; } }
-		public override HttpServerUtilityBase Server { get { return server; } }
-		public override ProfileBase Profile { get { return profile; } }
-		public override IHttpHandler PreviousHandler { get { return previousHandler; } }
-		public override bool IsPostNotification { get { return isPostNotification; } }
-		public override bool IsDebuggingEnabled { get { return isDebuggingEnabled; } }
-		public override bool IsCustomErrorEnabled { get { return isCustomErrorEnabled; } }
-		public override IHttpHandler Handler { get { return handler; } set { handler = value; } }
-		public override Exception Error { get { return error; } }
-		public override RequestNotification CurrentNotification { get { return currentNotification; } }
-		public override IHttpHandler CurrentHandler { get { return currentHandler; } }
-		public override Cache Cache { get { return cache; } }
-		public override HttpApplication ApplicationInstance { get { return applicationInstance; } set { applicationInstance = value; } }
-		public override HttpApplicationStateBase Application { get { return application; } }
-		public override Exception[] AllErrors { get { return allErrors; } }
-	}
+        public override IPrincipal User { get { return Control.User; } set { Control.User = value; } }
+
+        public override TraceContext Trace
+        {
+            get { return Control.TraceContext; }
+        }
+
+        public override DateTime Timestamp
+        {
+            get { return Control.TimeStamp; }
+        }
+
+        public override bool SkipAuthorization { get; set; }
+
+        public override HttpServerUtilityBase Server
+        {
+            get { return Control.Server; }
+        }
+
+        public override ProfileBase Profile
+        {
+            get { return _profile; }
+        }
+
+        public override IHttpHandler PreviousHandler
+        {
+            get { return Control.PreviousHandler; }
+        }
+
+        public override bool IsPostNotification
+        {
+            get { return Control.IsPostNotification; }
+        }
+
+        public override bool IsDebuggingEnabled
+        {
+            get { return Control.IsDebuggingEnabled; }
+        }
+
+        public override bool IsCustomErrorEnabled
+        {
+            get { return Control.IsCustomErrorsEnabled; }
+        }
+
+        public override IHttpHandler Handler
+        {
+            get { return Control.Handler; }
+            set { Control.Handler = value; }
+        }
+
+        public override Exception Error
+        {
+            get { return Control.Error; }
+        }
+
+        public override RequestNotification CurrentNotification
+        {
+            get { return Control.CurrentNotification; }
+        }
+
+        public override IHttpHandler CurrentHandler
+        {
+            get { return Control.CurrentHandler; }
+        }
+
+        public override Cache Cache
+        {
+            get { return Control.Cache; }
+        }
+
+        public override HttpApplication ApplicationInstance
+        {
+            get { return Control.ApplicationInstance; }
+            set { Control.ApplicationInstance = new FakeHttpApplication(value); }
+        }
+
+        public override HttpApplicationStateBase Application
+        {
+            get { return Control.Application; }
+        }
+
+        public override Exception[] AllErrors
+        {
+            get { return Control.AllErrors.ToArray(); }
+        }
+    }
 }

--- a/src/Web/FakeHttpContextBuilder.cs
+++ b/src/Web/FakeHttpContextBuilder.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Principal;
+
+namespace FakeN.Web
+{
+    /// <summary>
+    ///     Use this class to build a fake request easily.
+    /// </summary>
+    /// <example>
+    /// <para>Basic</para>
+    ///     <code>
+    /// <![CDATA[
+    /// var builder = new FakeHttpContextBuilder();
+    /// builder.Get("http://localhost/hello?a=1")
+    ///        .RespondWith("<html><body>Hello World!</body></html>");
+    /// 
+    /// var httpContext = builder.Build();
+    /// ]]>
+    /// </code>
+    /// <para>With session:</para>
+    /// <code>
+    /// <![CDATA[
+    /// var builder = new FakeHttpContextBuilder();
+    /// builder.Post("http://localhost/hello?a=1")
+    ///        .RespondWith("<html><body>Hello World!</body></html>")
+    ///        .UsingSession(new { UserId = 1 });
+    /// 
+    /// var httpContext = builder.Build();
+    /// ]]>
+    /// </code>
+    /// <para>With principal:</para>
+    /// <code>
+    /// <![CDATA[
+    /// var builder = new FakeHttpContextBuilder();
+    /// builder.Put("http://localhost/hello?a=1")
+    ///        .RespondWith("<html><body>Hello World!</body></html>")
+    ///        .UsePrincipal(new GenericPrincipal(/*....*));
+    /// 
+    /// var httpContext = builder.Build();
+    /// ]]>
+    /// </code>
+    /// </example>
+    public class FakeHttpContextBuilder
+    {
+        private FakeHttpRequestBuilder _request;
+        private FakeHttpResponseBuilder _response;
+        private IDictionary<string, object> _session;
+        private IPrincipal _principal;
+
+        /// <summary>
+        /// Used to serialize the body for <see cref="RespondWith(object,string)"/>.
+        /// </summary>
+        [ThreadStatic]
+        public static Func<object, string> BodySerializer;
+        public FakeHttpContext Build()
+        {
+            var request = _request == null ? new FakeHttpRequest(new Uri("http://localhost/")) : _request.BuildRequest();
+            var response = _response == null ? new FakeHttpResponse() : _response.BuildResponse();
+
+            request.InputStream.Position = 0;
+            response.OutputStream.Position = 0;
+
+            var ctx = new FakeHttpContext(request, response, _session == null ? null : new FakeHttpSessionState(_session));
+
+            if (_principal != null)
+                ctx.User = _principal;
+            return ctx;
+        }
+
+        public FakeHttpRequestBuilder Post(string url)
+        {
+            _request = new FakeHttpRequestBuilder(this, url, "POST");
+            return _request;
+        }
+
+        public FakeHttpRequestBuilder Put(string url)
+        {
+            _request = new FakeHttpRequestBuilder(this, url, "PUT");
+            return _request;
+        }
+
+        public FakeHttpRequestBuilder Get(string url)
+        {
+            _request = new FakeHttpRequestBuilder(this, url, "GET");
+            return _request;
+        }
+
+        public FakeHttpRequestBuilder Delete(string url)
+        {
+            _request = new FakeHttpRequestBuilder(this, url, "DELETE");
+            return _request;
+        }
+
+        public FakeHttpContextBuilder LocalFolderIs(string folder)
+        {
+            return this;
+        }
+
+        public FakeHttpResponseBuilder RespondWith()
+        {
+            _response = new FakeHttpResponseBuilder(this);
+            return _response;
+        }
+
+        public FakeHttpContextBuilder RespondWith(string htmlBody, string contentType = "text/html")
+        {
+            _response = new FakeHttpResponseBuilder(this, htmlBody, contentType);
+            return this;
+        }
+
+        /// <summary>
+        /// Requires that <see cref="BodySerializer"/> is specified.
+        /// </summary>
+        /// <param name="body"></param>
+        /// <param name="contentType"></param>
+        /// <returns></returns>
+        public FakeHttpContextBuilder RespondWith(object body, string contentType = "application/json")
+        {
+            _response = new FakeHttpResponseBuilder(this, BodySerializer(body), contentType);
+            return this;
+        }
+
+
+
+        public FakeHttpContextBuilder UsingSession(IDictionary<string, object> session)
+        {
+            _session = session;
+            return this;
+        }
+
+        public FakeHttpContextBuilder UsePrincipal(IPrincipal principal)
+        {
+            _principal = principal;
+            return this;
+        }
+
+        public FakeHttpContextBuilder UsingSession(object anonObject)
+        {
+            _session = Helper.ToDictionary(anonObject);
+            return this;
+        }
+
+        public FakeHttpContextBuilder VirtualRootIs(string absolutePath)
+        {
+            return this;
+        }
+    }
+}

--- a/src/Web/FakeHttpContextBuilder.cs
+++ b/src/Web/FakeHttpContextBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Security.Principal;
 
 namespace FakeN.Web
@@ -118,6 +119,20 @@ namespace FakeN.Web
         public FakeHttpContextBuilder RespondWith(object body, string contentType = "application/json")
         {
             _response = new FakeHttpResponseBuilder(this, BodySerializer(body), contentType);
+            return this;
+        }
+
+        public FakeHttpContextBuilder RespondWith(int statusCode)
+        {
+            _response = new FakeHttpResponseBuilder(this);
+            _response.Status(statusCode);
+            return this;
+        }
+
+        public FakeHttpContextBuilder RespondWith(HttpStatusCode statusCode)
+        {
+            _response = new FakeHttpResponseBuilder(this);
+            _response.Status(statusCode);
             return this;
         }
 

--- a/src/Web/FakeHttpContextControl.cs
+++ b/src/Web/FakeHttpContextControl.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Principal;
+using System.Web;
+using System.Web.Caching;
+
+namespace FakeN.Web
+{
+    public class FakeHttpContextControl
+    {
+        private readonly FakeHttpContext _httpContext;
+        private FakeHttpRequest _request;
+        private FakeHttpResponse _response;
+
+        public FakeHttpContextControl(FakeHttpRequest request = null,
+            FakeHttpResponse response = null,
+            FakeHttpSessionState session = null)
+        {
+            AllErrors = new List<Exception>();
+            ApplicationInstance = new FakeHttpApplication();
+            Application = new FakeHttpStateBase();
+            CurrentHandler = new DefaultHttpHandler();
+            Items = new Dictionary<object, object>();
+            Request = request ?? new FakeHttpRequest();
+            Response = response ?? new FakeHttpResponse();
+            Server = new FakeHttpServerUtilityBase();
+            Session = session ?? new FakeHttpSessionState();
+            TimeStamp = DateTime.Now;
+            User = new GenericPrincipal(new MutableIdentity(), new string[] { });
+        }
+
+        public FakeHttpContextControl()
+            : this(null, null, null)
+        {
+        }
+
+        public FakeHttpContextControl(FakeHttpContext httpContext)
+            : this()
+        {
+            _httpContext = httpContext;
+        }
+
+        public IPrincipal User { get; set; }
+        public Dictionary<object, object> Items { get; set; }
+
+        public FakeHttpRequest Request
+        {
+            get { return _request; }
+            set
+            {
+                _request = value;
+                _request.Control.HttpContext = _httpContext;
+            }
+        }
+
+        public FakeHttpResponse Response
+        {
+            get { return _response; }
+            set
+            {
+                _response = value;
+            }
+        }
+
+        public HttpSessionStateBase Session { get; set; }
+        public TraceContext TraceContext { get; set; }
+        public FakeHttpServerUtilityBase Server { get; set; }
+        public IHttpHandler PreviousHandler { get; set; }
+        public bool IsPostNotification { get; set; }
+        public bool IsDebuggingEnabled { get; set; }
+        public Exception Error { get; set; }
+        public RequestNotification CurrentNotification { get; set; }
+        public IHttpHandler CurrentHandler { get; set; }
+        public Cache Cache { get; set; }
+        public FakeHttpApplication ApplicationInstance { get; set; }
+        public FakeHttpStateBase Application { get; set; }
+        public List<Exception> AllErrors { get; set; }
+        public DateTime TimeStamp { get; set; }
+        public bool IsCustomErrorsEnabled { get; set; }
+        public IHttpHandler Handler { get; set; }
+    }
+}

--- a/src/Web/FakeHttpRequest.cs
+++ b/src/Web/FakeHttpRequest.cs
@@ -9,112 +9,68 @@ using System.Web;
 using System.Web.Routing;
 
 namespace FakeN.Web {
-
-	public interface IHttpObject { }
-
-	public class FakeHttpRequest : HttpRequestBase, IHttpObject {
-		private readonly NameValueCollection form;
-		private readonly NameValueCollection queryString;
-		private readonly NameValueCollection headers;
-		private readonly NameValueCollection serverVariables;
-		private readonly HttpCookieCollection cookies;
-		private HttpFileCollectionBase files;
-		private Uri url;
-		private string method;
-		private bool isLocal;
-		private string userHostAddress;
-		private string applicationPath;
-		private string[] acceptTypes;
-		private Stream inputStream;
-		private bool isAuthenticated;
-
-		private string anonymousId;
-		private string appRelativeCurrentExecutionFilePath;
-		private HttpBrowserCapabilitiesBase browser;
-		private ChannelBinding httpChannelBinding;
-		private HttpClientCertificate clientCertificate;
-		private int contentLength;
-		private string currentExecutionFilePath;
-		private Stream filter;
-		private bool isSecureConnection;
-		private WindowsIdentity logonUserIdentity;
-		private NameValueCollection @params;
-		private string physicalApplicationPath;
-		private string physicalPath;
-		private RequestContext requestContext;
-		private int totalBytes;
-		private Uri urlReferrer;
-		private string userAgent;
-		private string[] userLanguages;
-		private string userHostName;
-		private string pathInfo;
-
-		private static NameValueCollection ParseQueryString(string url) {
-			return HttpUtility.ParseQueryString(url);
-		}
-
+    public class FakeHttpRequest : HttpRequestBase, IHttpObject {
+		
 		public FakeHttpRequest(Uri url = null, string method = "GET") {
-			this.url = url ?? new Uri("http://localhost");
-			this.method = method;
-			acceptTypes = new string[] { };
-			queryString = ParseQueryString(this.url.Query);
-			form = new NameValueCollection();
-			headers = new NameValueCollection();
-			serverVariables = new NameValueCollection();
-			cookies = new HttpCookieCollection();
+            Control = new FakeHttpRequestControl(url, method);
 		}
 
-		public FakeHttpRequest SetUrl(Uri url) {
-			this.url = url;
-			queryString.Clear();
-			queryString.Add(ParseQueryString(url.Query));
+		public FakeHttpRequest SetUrl(Uri url)
+		{
+		    Control.SetUrl(url);
 			return this;
 		}
 
+        /// <summary>
+        /// Used to control what this request returns.
+        /// </summary>
+        public FakeHttpRequestControl Control { get; set; }
+
 		public override string this[string key] {
-			get { return new NameValueCollection { form, queryString }[key]; }
+            get { return new NameValueCollection { Control.Form, Control.QueryString }[key]; }
 		}
 
-		public override bool IsAuthenticated { get { return isAuthenticated; } }
-		public override Uri Url { get { return url; } }
-		public override bool IsLocal { get { return isLocal; } }
-		public override string ApplicationPath { get { return applicationPath; } }
-		public override string HttpMethod { get { return method; } }
-		public override string UserHostAddress { get { return userHostAddress; } }
-		public override string[] AcceptTypes { get { return acceptTypes; } }
+        public override bool IsAuthenticated { get { return Control.IsAuthenticated; } }
+        public override Uri Url { get { return Control.Url; } }
+        public override bool IsLocal { get { return Control.IsLocal; } }
+        public override string ApplicationPath { get { return Control.ApplicationPath; } }
+        public override string HttpMethod { get { return Control.HttpMethod; } }
+        public override string UserHostAddress { get { return Control.UserHostAddress; } }
+        public override string[] AcceptTypes { get { return Control.AcceptTypes.ToArray(); } }
 		public override string RequestType { get; set; }
 		public override string ContentType { get; set; }
 		public override Encoding ContentEncoding { get; set; }
 		public override void ValidateInput() { }
-		public override string RawUrl { get { return url.PathAndQuery; } }
-		public override NameValueCollection Form { get { return form; } }
-		public override NameValueCollection QueryString { get { return queryString; } }
-		public override NameValueCollection Headers { get { return headers; } }
-		public override NameValueCollection ServerVariables { get { return serverVariables; } }
-		public override HttpCookieCollection Cookies { get { return cookies; } }
-		public override HttpFileCollectionBase Files { get { return files; } }
+        public override string RawUrl { get { return Control.Url.PathAndQuery; } }
+        public override NameValueCollection Form { get { return Control.Form; } }
+        public override NameValueCollection QueryString { get { return Control.QueryString; } }
+        public override NameValueCollection Headers { get { return Control.Headers; } }
+        public override NameValueCollection ServerVariables { get { return Control.ServerVariables; } }
+        public override HttpCookieCollection Cookies { get { return Control.Cookies; } }
+        public override HttpFileCollectionBase Files { get { return Control.Files; } }
 		public override string Path { get { return Url.AbsolutePath; } }
 		public override string FilePath { get { return Url.AbsolutePath; } }
-		public override string PathInfo { get { return pathInfo; } }
-		public override Stream InputStream { get { return inputStream; } }
-		public override string AnonymousID { get { return anonymousId; } }
-		public override string AppRelativeCurrentExecutionFilePath { get { return appRelativeCurrentExecutionFilePath; } }
-		public override HttpBrowserCapabilitiesBase Browser { get { return browser; } }
-		public override ChannelBinding HttpChannelBinding { get { return httpChannelBinding; } }
-		public override HttpClientCertificate ClientCertificate { get { return clientCertificate; } }
-		public override int ContentLength { get { return contentLength; } }
-		public override string CurrentExecutionFilePath { get { return currentExecutionFilePath; } }
-		public override Stream Filter { get { return filter; } set { filter = value; } }
-		public override bool IsSecureConnection { get { return isSecureConnection; } }
-		public override WindowsIdentity LogonUserIdentity { get { return logonUserIdentity; } }
-		public override NameValueCollection Params { get { return @params; } }
-		public override string PhysicalApplicationPath { get { return physicalApplicationPath; } }
-		public override string PhysicalPath { get { return physicalPath; } }
-		public override RequestContext RequestContext { get { return requestContext; } }
-		public override int TotalBytes { get { return totalBytes; } }
-		public override Uri UrlReferrer { get { return urlReferrer; } }
-		public override string UserAgent { get { return userAgent; } }
-		public override string[] UserLanguages { get { return userLanguages; } }
-		public override string UserHostName { get { return userHostName; } }
-	}
+        public override string PathInfo { get { return Control.PathInfo; } }
+        public override Stream InputStream { get { return Control.InputStream; } }
+        public override string AnonymousID { get { return Control.AnonymousId; } }
+        public override string AppRelativeCurrentExecutionFilePath { get { return Control.AppRelativeCurrentExecutionFilePath; } }
+        public override HttpBrowserCapabilitiesBase Browser { get { return Control.Browser; } }
+        public override ChannelBinding HttpChannelBinding { get { return Control.HttpChannelBinding; } }
+        public override HttpClientCertificate ClientCertificate { get { return Control.ClientCertificate; } }
+        public override int ContentLength { get { return Control.ContentLength; } }
+        public override string CurrentExecutionFilePath { get { return Control.CurrentExecutionFilePath; } }
+        public override Stream Filter { get { return Control.Filter; } set { Control.Filter = value; } }
+        public override bool IsSecureConnection { get { return Control.IsSecureConnection; } }
+        public override WindowsIdentity LogonUserIdentity { get { return Control.LogonUserIdentity; } }
+        public override NameValueCollection Params { get { return Control.Params; } }
+        public override string PhysicalApplicationPath { get { return Control.PhysicalApplicationPath; } }
+        public override string PhysicalPath { get { return Control.PhysicalPath; } }
+        public override RequestContext RequestContext { get { return Control.RequestContext; } }
+        public override int TotalBytes { get { return Control.TotalBytes; } }
+        public override Uri UrlReferrer { get { return Control.UrlReferrer; } }
+        public override string UserAgent { get { return Control.UserAgent; } }
+        public override string[] UserLanguages { get { return Control.UserLanguages.ToArray(); } }
+        public override string UserHostName { get { return Control.UserHostName; } }
+
+    }
 }

--- a/src/Web/FakeHttpRequestBuilder.cs
+++ b/src/Web/FakeHttpRequestBuilder.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Specialized;
+using System.IO;
+using System.Text;
+using System.Web;
+
+namespace FakeN.Web
+{
+    public class FakeHttpRequestBuilder
+    {
+        private readonly FakeHttpContextBuilder _builder;
+        private readonly string _url;
+        private FakeHttpRequest _request;
+        public FakeHttpRequestBuilder(FakeHttpContextBuilder builder, string url, string method)
+        {
+            _builder = builder;
+            _url = url;
+            _request = new FakeHttpRequest(new Uri(url)) {Control = {HttpMethod = method}};
+        }
+
+        public FakeHttpRequestBuilder WithForm(NameValueCollection form)
+        {
+            _request.Control.Form = form;
+            return this;
+        }
+
+        public FakeHttpRequestBuilder WithForm(object anonObject)
+        {
+            _request.Control.Form = Helper.ToNameValue(anonObject);
+            return this;
+        }
+
+        public FakeHttpRequestBuilder WithBody(string body, string contentType = "application/x-form-url-encoded")
+        {
+            _request.Control.Headers.Add("Content-Type", contentType);
+            var buf = Encoding.UTF8.GetBytes(body);
+            _request.Control.InputStream.Write(buf,0,buf.Length);
+            return this;
+        }
+
+        public FakeHttpRequestBuilder WithJsonBody(string body)
+        {
+            _request.Control.Headers.Add("Content-Type", "application/json");
+            var buf = Encoding.UTF8.GetBytes(body);
+            _request.Control.InputStream.Write(buf,0,buf.Length);
+            return this;
+        }
+        
+        public FakeHttpRequestBuilder WithBinaryBody(Stream body, string contentType = "application/octet-stream")
+        {
+            _request.Control.Headers.Add("Content-Type", contentType);
+            _request.Control.InputStream = body;
+            return this;
+        }
+
+        public FakeHttpRequestBuilder WithBinaryBody(byte[] body, string contentType = "application/octet-stream")
+        {
+            _request.Control.Headers.Add("Content-Type", contentType);
+            _request.Control.InputStream.Write(body, 0, body.Length);
+            return this;
+        }
+
+        public FakeHttpRequest BuildRequest()
+        {
+            return _request;
+        }
+
+
+        public FakeHttpResponseBuilder RespondWith()
+        {
+            return _builder.RespondWith();
+        }
+
+        public FakeHttpContextBuilder RespondWith(string body, string contentType = "text/html")
+        {
+            return _builder.RespondWith(body, contentType);
+        }
+
+        /// <summary>
+        /// Requires that <see cref="FakeHttpContextBuilder.BodySerializer"/> is specified.
+        /// </summary>
+        /// <param name="body"></param>
+        /// <param name="contentType"></param>
+        /// <returns></returns>
+        public FakeHttpContextBuilder RespondWith(object body, string contentType = "application/json")
+        {
+            return _builder.RespondWith(body, contentType);
+        }
+
+        public FakeHttpRequestBuilder AddCookie(string name, string value)
+        {
+            _request.Cookies.Add(new HttpCookie(name, value));
+            return this;
+        }
+
+        public FakeHttpRequestBuilder AddCookie(HttpCookie cookie)
+        {
+            _request.Cookies.Add(cookie);
+            return this;
+        }
+    }
+}

--- a/src/Web/FakeHttpRequestBuilder.cs
+++ b/src/Web/FakeHttpRequestBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Specialized;
 using System.IO;
+using System.Net;
 using System.Text;
 using System.Web;
 
@@ -70,6 +71,17 @@ namespace FakeN.Web
         {
             return _builder.RespondWith();
         }
+
+        public FakeHttpContextBuilder RespondWith(int statusCode)
+        {
+            return _builder.RespondWith(statusCode);
+        }
+
+        public FakeHttpContextBuilder RespondWith(HttpStatusCode statusCode)
+        {
+            return _builder.RespondWith(statusCode);
+        }
+
 
         public FakeHttpContextBuilder RespondWith(string body, string contentType = "text/html")
         {

--- a/src/Web/FakeHttpRequestControl.cs
+++ b/src/Web/FakeHttpRequestControl.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Security.Authentication.ExtendedProtection;
+using System.Security.Principal;
+using System.Web;
+using System.Web.Routing;
+
+namespace FakeN.Web
+{
+    public class FakeHttpRequestControl
+    {
+        private NameValueCollection _params;
+        private int _contentLength = -1;
+        private FakeHttpContext _httpContext;
+
+        public FakeHttpRequestControl(Uri url = null, string httpMethod = "GET")
+        {
+            Url = url ?? new Uri("http://localhost");
+            HttpMethod = httpMethod;
+            AcceptTypes = new List<string>();
+            UserLanguages = new List<string>() {"en-US"};
+            QueryString = HttpUtility.ParseQueryString(Url.Query);
+            Form = new NameValueCollection();
+            Headers = new NameValueCollection();
+            ServerVariables = new NameValueCollection();
+            Cookies = new HttpCookieCollection();
+            InputStream = new MemoryStream();
+            PathInfo = "";
+            PhysicalApplicationPath = "C:\\temp";
+            PhysicalPath = Path.Combine(PhysicalApplicationPath, Url.AbsolutePath.TrimStart('/').Replace('/', '\\'));
+            RequestContext = new FakeRequestContext();
+        }
+
+        public FakeHttpContext HttpContext
+        {
+            get { return _httpContext; }
+            set
+            {
+                _httpContext = value;
+                RequestContext.HttpContext = value;
+            }
+        }
+
+        public HttpCookieCollection Cookies { get; set; }
+        public NameValueCollection Form { get; set; }
+        public NameValueCollection Headers { get; set; }
+        public NameValueCollection QueryString { get; set; }
+        public NameValueCollection ServerVariables { get; set; }
+        public List<string> AcceptTypes { get; set; }
+        public string AnonymousId { get; set; }
+        public string ApplicationPath { get; set; }
+        public string AppRelativeCurrentExecutionFilePath { get; set; }
+        public HttpBrowserCapabilitiesBase Browser { get; set; }
+        public HttpClientCertificate ClientCertificate { get; set; }
+
+        public int ContentLength
+        {
+            get
+            {
+                return (int) (_contentLength != -1 ?  _contentLength : InputStream.Length);
+            }
+            set { _contentLength = value; }
+        }
+
+        public string CurrentExecutionFilePath { get; set; }
+        public HttpFileCollectionBase Files { get; set; }
+        public Stream Filter { get; set; }
+        public ChannelBinding HttpChannelBinding { get; set; }
+        public Stream InputStream { get; set; }
+        public bool IsAuthenticated { get; set; }
+        public bool IsLocal { get; set; }
+        public bool IsSecureConnection { get; set; }
+        public WindowsIdentity LogonUserIdentity { get; set; }
+        public string HttpMethod { get; set; }
+
+        public NameValueCollection Params
+        {
+            get
+            {
+                return _params ?? QueryString;
+            }
+            set { _params = value; }
+        }
+
+        public string PathInfo { get; set; }
+        public string PhysicalApplicationPath { get; set; }
+        public string PhysicalPath { get; set; }
+        public RequestContext RequestContext { get; set; }
+        public int TotalBytes { get; set; }
+        public Uri Url { get; set; }
+        public Uri UrlReferrer { get; set; }
+        public string UserAgent { get; set; }
+        public string UserHostAddress { get; set; }
+        public string UserHostName { get; set; }
+        public List<string> UserLanguages { get; set; }
+
+        public FakeHttpRequestControl SetUrl(Uri url)
+        {
+            this.Url = url;
+            QueryString.Clear();
+            QueryString.Add(HttpUtility.ParseQueryString(url.Query));
+            return this;
+        }
+    }
+}

--- a/src/Web/FakeHttpResponse.cs
+++ b/src/Web/FakeHttpResponse.cs
@@ -6,94 +6,164 @@ using System.Web;
 
 namespace FakeN.Web
 {
-	public class FakeHttpResponse : HttpResponseBase
-	{
-		private Func<string, string> appPathModifier;
+    public class FakeHttpResponse : HttpResponseBase
+    {
+        public FakeHttpResponse()
+        {
+            Control = new FakeHttpResponseControl();
+        }
 
-		private bool buffer;
+        public FakeHttpResponseControl Control { get; set; }
 
-		private bool bufferOutput;
+        public override HttpCachePolicyBase Cache
+        {
+            get { return new FakeHttpCachePolicy(); }
+        }
 
-		private string cacheControl;
+        public override int StatusCode
+        {
+            get { return Control.StatusCode; }
+            set { Control.StatusCode = value; }
+        }
 
-		private string charset;
+        public override string StatusDescription
+        {
+            get { return Control.StatusDescription; }
+            set { Control.StatusDescription = value; }
+        }
 
-		private Encoding contentEncoding;
+        public override int SubStatusCode { get; set; }
 
-		private string contentType;
+        public override bool Buffer
+        {
+            get { return Control.Buffer; }
+            set { Control.Buffer = value; }
+        }
 
-		private HttpCookieCollection cookies;
+        public override bool BufferOutput
+        {
+            get { return Control.BufferOutput; }
+            set { Control.BufferOutput = value; }
+        }
 
-		private int expires;
+        public override string CacheControl
+        {
+            get { return Control.CacheControl; }
+            set { Control.CacheControl = value; }
+        }
 
-		private DateTime expiresAbsolute;
+        public override string Charset
+        {
+            get { return Control.Charset; }
+            set { Control.Charset = value; }
+        }
 
-		private Stream filter;
+        public override Encoding ContentEncoding
+        {
+            get { return Control.ContentEncoding; }
+            set { Control.ContentEncoding = value; }
+        }
 
-		private NameValueCollection headers;
+        public override string ContentType
+        {
+            get { return Control.ContentType; }
+            set { Control.ContentType = value; }
+        }
 
-		private Encoding headerEncoding;
+        public override HttpCookieCollection Cookies
+        {
+            get { return Control.Cookies; }
+        }
 
-		private bool isClientConnected;
+        public override int Expires
+        {
+            get { return Control.Expires; }
+            set { Control.Expires = value; }
+        }
 
-		private bool isRequestBeingRedirected;
+        public override DateTime ExpiresAbsolute
+        {
+            get { return Control.ExpiresAbsolute; }
+            set { Control.ExpiresAbsolute = value; }
+        }
 
-		private TextWriter output;
+        public override Stream Filter
+        {
+            get { return Control.Filter; }
+            set { Control.Filter = value; }
+        }
 
-		private Stream outputStream;
+        public override NameValueCollection Headers
+        {
+            get { return Control.Headers; }
+        }
 
-		private string redirectLocation;
+        public override Encoding HeaderEncoding
+        {
+            get { return Control.HeaderEncoding; }
+            set { Control.HeaderEncoding = value; }
+        }
 
-		private string status;
+        public override bool IsClientConnected
+        {
+            get { return Control.IsClientConnected; }
+        }
 
-		private bool suppressContent;
+        public override bool IsRequestBeingRedirected
+        {
+            get { return Control.IsRequestBeingRedirected; }
+        }
 
-		private bool trySkipIisCustomErrors;
+        public override TextWriter Output
+        {
+            get { return Control.Output; }
+            set { Control.Output = value; }
+        }
 
-		public FakeHttpResponse()
-		{
-			appPathModifier = x => x;
-		}
+        public override Stream OutputStream
+        {
+            get { return Control.OutputStream; }
+        }
 
-		public override HttpCachePolicyBase Cache
-		{
-			get { return new FakeHttpCachePolicy(); }
-		}
+        public override string RedirectLocation
+        {
+            get { return Control.RedirectLocation; }
+            set { Control.RedirectLocation = value; }
+        }
 
-		public override string ApplyAppPathModifier(string virtualPath)
-		{
-			return appPathModifier(virtualPath);
-		}
+        /// <summary>
+        /// When overridden in a derived class, gets or sets the Status value that is returned to the client.
+        /// </summary>
+        /// <returns>
+        /// The status of the HTTP output. For information about valid status codes, see HTTP Status Codes on the MSDN Web site.
+        /// </returns>
+        public override string Status
+        {
+            get { return Control.Status ?? StatusCode.ToString(); }
+            set { Control.Status = value; }
+        }
 
-		public FakeHttpResponse SetAppPathModifier(Func<string, string> appPathModifier)
-		{
-			this.appPathModifier = appPathModifier;
-			return this;
-		}
+        public override bool SuppressContent
+        {
+            get { return Control.SuppressContent; }
+            set { Control.SuppressContent = value; }
+        }
 
-		public override int StatusCode { get; set; }
-		public override string StatusDescription { get; set; }
-		public override int SubStatusCode { get; set; }
+        public override bool TrySkipIisCustomErrors
+        {
+            get { return Control.TrySkipIisCustomErrors; }
+            set { Control.TrySkipIisCustomErrors = value; }
+        }
 
-		public override bool Buffer { get { return buffer; } set { buffer = value; } }
-		public override bool BufferOutput { get { return bufferOutput; } set { bufferOutput = value; } }
-		public override string CacheControl { get { return cacheControl; } set { cacheControl = value; } }
-		public override string Charset { get { return charset; } set { charset = value; } }
-		public override Encoding ContentEncoding { get { return contentEncoding; } set { contentEncoding = value; } }
-		public override string ContentType { get { return contentType; } set { contentType = value; } }
-		public override HttpCookieCollection Cookies { get { return cookies; } }
-		public override int Expires { get { return expires; } set { expires = value; } }
-		public override DateTime ExpiresAbsolute { get { return expiresAbsolute; } set { expiresAbsolute = value; } }
-		public override Stream Filter { get { return filter; } set { filter = value; } }
-		public override NameValueCollection Headers { get { return headers; } }
-		public override Encoding HeaderEncoding { get { return headerEncoding; } set { headerEncoding = value; } }
-		public override bool IsClientConnected { get { return isClientConnected; } }
-		public override bool IsRequestBeingRedirected { get { return isRequestBeingRedirected; } }
-		public override TextWriter Output { get { return output; } set { output = value; } }
-		public override Stream OutputStream { get { return outputStream; } }
-		public override string RedirectLocation { get { return redirectLocation; } set { redirectLocation = value; } }
-		public override string Status { get { return status; } set { status = value; } }
-		public override bool SuppressContent { get { return suppressContent; } set { suppressContent = value; } }
-		public override bool TrySkipIisCustomErrors { get { return trySkipIisCustomErrors; } set { trySkipIisCustomErrors = value; } }
-	}
+        public override string ApplyAppPathModifier(string virtualPath)
+        {
+            return Control.AppPathModifier(virtualPath);
+        }
+
+        public FakeHttpResponse SetAppPathModifier(Func<string, string> appPathModifier)
+        {
+            Control.AppPathModifier = appPathModifier;
+            return this;
+        }
+    }
 }

--- a/src/Web/FakeHttpResponseBuilder.cs
+++ b/src/Web/FakeHttpResponseBuilder.cs
@@ -1,0 +1,78 @@
+using System.IO;
+using System.Net;
+using System.Text;
+
+namespace FakeN.Web
+{
+    public class FakeHttpResponseBuilder
+    {
+        private readonly FakeHttpContextBuilder _httpContextBuilder;
+        private readonly  FakeHttpResponse _response = new FakeHttpResponse();
+
+        public FakeHttpResponseBuilder(FakeHttpContextBuilder httpContextBuilder)
+        {
+            _httpContextBuilder = httpContextBuilder;
+        }
+
+        public FakeHttpResponseBuilder(FakeHttpContextBuilder httpContextBuilder, string htmlBody)
+        {
+            _httpContextBuilder = httpContextBuilder;
+            WithBody(htmlBody);
+        }
+
+        public FakeHttpResponseBuilder(FakeHttpContextBuilder httpContextBuilder, string body, string contentType)
+        {
+            _httpContextBuilder = httpContextBuilder;
+            WithBody(body, contentType);
+        }
+
+        public FakeHttpResponseBuilder Status(HttpStatusCode statusCode, string statusDescription = null)
+        {
+            _response.StatusCode = (int)statusCode;
+            _response.StatusDescription = statusDescription ?? statusCode.ToString();
+            return this;
+        }
+
+        public FakeHttpResponseBuilder Status(int statusCode, string statusDescription = null)
+        {
+            _response.StatusCode = statusCode;
+            _response.StatusDescription = statusDescription ?? statusCode.ToString();
+            return this;
+        }
+
+
+        public FakeHttpResponseBuilder WithBody(string body, string contentType = "text/html")
+        {
+            _response.Control.Headers.Add("Content-Type", contentType);
+            var buf = Encoding.UTF8.GetBytes(body);
+            _response.Control.OutputStream.Write(buf, 0, buf.Length);
+            return this;
+        }
+
+        public FakeHttpResponseBuilder WithJsonBody(string body)
+        {
+            _response.Control.Headers.Add("Content-Type", "application/json");
+            var buf = Encoding.UTF8.GetBytes(body);
+            _response.Control.OutputStream.Write(buf, 0, buf.Length);
+            return this;
+        }
+
+        public FakeHttpResponseBuilder WithBinaryBody(Stream body, string contentType = "application/octet-stream")
+        {
+            _response.Control.Headers.Add("Content-Type", contentType);
+            _response.Control.OutputStream = body;
+            return this;
+        }
+
+        public FakeHttpResponse BuildResponse()
+        {
+            return _response;
+        }
+
+        public FakeHttpContext Build()
+        {
+            return _httpContextBuilder.Build();
+        }
+
+    }
+}

--- a/src/Web/FakeHttpResponseControl.cs
+++ b/src/Web/FakeHttpResponseControl.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Specialized;
+using System.IO;
+using System.Text;
+using System.Web;
+
+namespace FakeN.Web
+{
+    public class FakeHttpResponseControl
+    {
+        public FakeHttpResponseControl()
+		{
+            AppPathModifier = x => x;
+            Charset = "utf-8";
+            ContentEncoding = Encoding.UTF8;
+            ContentType = "text/html";
+            Cookies = new HttpCookieCollection();
+            Expires = 60;
+            ExpiresAbsolute = DateTime.Now.AddSeconds(60);
+            Headers = new NameValueCollection();
+            OutputStream = new MemoryStream();
+            Output = new StreamWriter(OutputStream);
+            StatusCode = 200;
+            StatusDescription = "OK";
+		}
+
+        public Func<string, string> AppPathModifier { get; set; }
+
+        public bool Buffer { get; set; }
+
+        public bool BufferOutput { get; set; }
+
+        public string CacheControl { get; set; }
+
+        public string Charset { get; set; }
+
+        public Encoding ContentEncoding { get; set; }
+
+        public string ContentType { get; set; }
+
+        public HttpCookieCollection Cookies { get; set; }
+
+        public int Expires { get; set; }
+
+        public DateTime ExpiresAbsolute { get; set; }
+
+        public Stream Filter { get; set; }
+
+        public NameValueCollection Headers { get; set; }
+
+        public Encoding HeaderEncoding { get; set; }
+
+        public bool IsClientConnected { get; set; }
+
+        public bool IsRequestBeingRedirected { get; set; }
+
+        public TextWriter Output { get; set; }
+
+        public Stream OutputStream { get; set; }
+
+        public string RedirectLocation { get; set; }
+
+        public string Status { get; set; }
+
+        public bool SuppressContent { get; set; }
+
+        public bool TrySkipIisCustomErrors { get; set; }
+        public int StatusCode { get; set; }
+        public string StatusDescription { get; set; }
+    }
+}

--- a/src/Web/FakeHttpServerUtilityBase.cs
+++ b/src/Web/FakeHttpServerUtilityBase.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Web;
+
+namespace FakeN.Web
+{
+    public class FakeHttpServerUtilityBase : HttpServerUtilityBase
+    {
+        public FakeHttpServerUtilityBase()
+        {
+            TransferRequests = new List<TransferRequest>();
+            MappedPaths = new Dictionary<string, string>();
+        }
+
+        /// <summary>
+        /// Contains all invocations to one of the <c>TransferRequest</c> overloads.
+        /// </summary>
+        public List<TransferRequest> TransferRequests { get; private set; }
+
+        /// <summary>
+        /// Use this property to be able to return custom values for <c>MapPath</c>.
+        /// </summary>
+        public IDictionary<string, string> MappedPaths { get; set; }
+
+        /// <summary>
+        ///     When overridden in a derived class, returns the physical file path that corresponds to the specified virtual path
+        ///     on the Web server.
+        /// </summary>
+        /// <returns>
+        ///     The physical file path that corresponds to <paramref name="path" />.
+        /// </returns>
+        /// <param name="path">The virtual path to get the physical path for.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override string MapPath(string path)
+        {
+            string mappedPath;
+            return !MappedPaths.TryGetValue(path, out mappedPath)
+                ? "/teststub/"
+                : mappedPath;
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, terminates execution of the current process and starts execution of a new
+        ///     request, using a custom HTTP handler and a value that specifies whether to clear the
+        ///     <see cref="P:System.Web.HttpRequestBase.QueryString" /> and <see cref="P:System.Web.HttpRequestBase.Form" />
+        ///     collections.
+        /// </summary>
+        /// <param name="handler">The HTTP handler to transfer the current request to.</param>
+        /// <param name="preserveForm">
+        ///     true to preserve the <see cref="P:System.Web.HttpRequest.QueryString" /> and
+        ///     <see cref="P:System.Web.HttpRequest.Form" /> collections; false to clear the
+        ///     <see cref="P:System.Web.HttpRequest.QueryString" /> and <see cref="P:System.Web.HttpRequest.Form" /> collections.
+        /// </param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void Transfer(IHttpHandler handler, bool preserveForm)
+        {
+            TransferRequests.Add(new TransferRequest(handler, preserveForm));
+            //base.Transfer(handler, preserveForm);
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, asynchronously executes the end point at the specified URL.
+        /// </summary>
+        /// <param name="path">The URL of the page or handler to execute.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void TransferRequest(string path)
+        {
+            TransferRequests.Add(new TransferRequest(path));
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, asynchronously executes the endpoint at the specified URL and specifies whether
+        ///     to clear the <see cref="P:System.Web.HttpRequestBase.QueryString" /> and
+        ///     <see cref="P:System.Web.HttpRequestBase.Form" /> collections.
+        /// </summary>
+        /// <param name="path">The URL of the page or handler to execute.</param>
+        /// <param name="preserveForm">
+        ///     true to preserve the <see cref="P:System.Web.HttpRequest.QueryString" /> and
+        ///     <see cref="P:System.Web.HttpRequest.Form" /> collections; false to clear the
+        ///     <see cref="P:System.Web.HttpRequest.QueryString" /> and <see cref="P:System.Web.HttpRequest.Form" /> collections.
+        /// </param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void TransferRequest(string path, bool preserveForm)
+        {
+            TransferRequests.Add(new TransferRequest(path, preserveForm));
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, asynchronously executes the endpoint at the specified URL by using the
+        ///     specified HTTP method and headers.
+        /// </summary>
+        /// <param name="path">The URL of the page or handler to execute.</param>
+        /// <param name="preserveForm">
+        ///     true to preserve the <see cref="P:System.Web.HttpRequest.QueryString" /> and
+        ///     <see cref="P:System.Web.HttpRequest.Form" /> collections; false to clear the
+        ///     <see cref="P:System.Web.HttpRequest.QueryString" /> and <see cref="P:System.Web.HttpRequest.Form" /> collections.
+        /// </param>
+        /// <param name="method">
+        ///     The HTTP method (GET, POST, and so on) to use for the new request. If null, the HTTP method of the
+        ///     original request is used.
+        /// </param>
+        /// <param name="headers">A collection of request headers for the new request.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void TransferRequest(string path, bool preserveForm, string method, NameValueCollection headers)
+        {
+            TransferRequests.Add(new TransferRequest(path, preserveForm, method, headers));
+        }
+    }
+}

--- a/src/Web/FakeHttpSessionState.cs
+++ b/src/Web/FakeHttpSessionState.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Specialized;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Web;
 using System.Web.SessionState;
 
@@ -27,7 +29,17 @@ namespace FakeN.Web
 			data = new SessionStateCollection();
 		}
 
-		public override object this[string name]
+	    public FakeHttpSessionState(IDictionary<string, object> session)
+	    {
+	        if (session == null) throw new ArgumentNullException("session");
+            data = new SessionStateCollection();
+            foreach (var kvp in session)
+	        {
+	            data[kvp.Key] = kvp.Value;
+	        }
+	    }
+
+	    public override object this[string name]
 		{
 			get { return data[name]; }
 			set { data[name] = value; }

--- a/src/Web/FakeHttpStateBase.cs
+++ b/src/Web/FakeHttpStateBase.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Web;
+
+namespace FakeN.Web
+{
+    /// <summary>
+    /// Use <c>AllStates</c> to control the content
+    /// </summary>
+    public class FakeHttpStateBase : HttpApplicationStateBase
+    {
+        public FakeHttpStateBase()
+        {
+            AllStates = new Dictionary<string, object>();
+        }
+
+        public Dictionary<string, object> AllStates { get; set; }
+
+        /// <summary>
+        ///     When overridden in a derived class, gets the access keys for the objects in the collection.
+        /// </summary>
+        /// <returns>
+        ///     An array of state object keys.
+        /// </returns>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override string[] AllKeys
+        {
+            get { return AllStates.Keys.ToArray(); }
+        }
+
+        /// <summary>
+        ///     Gets a <see cref="T:System.Collections.Specialized.NameObjectCollectionBase.KeysCollection" /> instance that
+        ///     contains all the keys in the <see cref="T:System.Collections.Specialized.NameObjectCollectionBase" /> instance.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="T:System.Collections.Specialized.NameObjectCollectionBase.KeysCollection" /> instance that contains
+        ///     all the keys in the <see cref="T:System.Collections.Specialized.NameObjectCollectionBase" /> instance.
+        /// </returns>
+        public override KeysCollection Keys
+        {
+            get
+            {
+                var col = new NameValueCollection();
+                foreach (var kvp in AllStates)
+                {
+                    col.Add(kvp.Key, kvp.Value.ToString());
+                }
+                return col.Keys;
+            }
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, gets a reference to the <see cref="T:System.Web.HttpApplicationStateBase" />
+        ///     object.
+        /// </summary>
+        /// <returns>
+        ///     A reference to the <see cref="T:System.Web.HttpApplicationState" /> object.
+        /// </returns>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override HttpApplicationStateBase Contents
+        {
+            get { return this; }
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, gets the number of objects in the collection.
+        /// </summary>
+        /// <returns>
+        ///     The number of objects in the collection.
+        /// </returns>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override int Count
+        {
+            get { return AllStates.Count; }
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, gets a state object by index.
+        /// </summary>
+        /// <returns>
+        ///     The object referenced by <paramref name="index" />.
+        /// </returns>
+        /// <param name="index">The index of the object in the collection.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override object this[int index]
+        {
+            get { return Get(index); }
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, gets a state object by name.
+        /// </summary>
+        /// <returns>
+        ///     The object referenced by <paramref name="name" />.
+        /// </returns>
+        /// <param name="name">The name of the object in the collection.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override object this[string name]
+        {
+            get { return AllStates[name]; }
+            set { AllStates[name] = value; }
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, adds a new object to the collection.
+        /// </summary>
+        /// <param name="name">The name of the object to add to the collection.</param>
+        /// <param name="value">The value of the object.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void Add(string name, object value)
+        {
+            AllStates.Add(name, value);
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, removes all objects from the collection.
+        /// </summary>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void Clear()
+        {
+            AllStates.Clear();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, copies the elements of the collection to an array, starting at the specified
+        ///     index in the array.
+        /// </summary>
+        /// <param name="array">
+        ///     The one-dimensional array that is the destination for the elements that are copied from the
+        ///     collection. The array must have zero-based indexing.
+        /// </param>
+        /// <param name="index">The zero-based index in <paramref name="array" /> at which to begin copying. </param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void CopyTo(Array array, int index)
+        {
+            var items = AllStates.Values.ToArray();
+            Array.Copy(items, 0, array, index, items.Length);
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, gets a state object by index.
+        /// </summary>
+        /// <returns>
+        ///     The object referenced by <paramref name="index" />.
+        /// </returns>
+        /// <param name="index">The index of the application state object to get.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override object Get(int index)
+        {
+            return AllStates.Values.ToArray()[index];
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, gets a state object by name.
+        /// </summary>
+        /// <returns>
+        ///     The object referenced by <paramref name="name" />.
+        /// </returns>
+        /// <param name="name">The name of the object to get.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override object Get(string name)
+        {
+            return AllStates[name];
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, returns an enumerator that can be used to iterate through the collection.
+        /// </summary>
+        /// <returns>
+        ///     An object that can be used to iterate through the collection.
+        /// </returns>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override IEnumerator GetEnumerator()
+        {
+            return AllStates.GetEnumerator();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, gets the name of a state object by index.
+        /// </summary>
+        /// <returns>
+        ///     The name of the application state object.
+        /// </returns>
+        /// <param name="index">The index of the application state object to get.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override string GetKey(int index)
+        {
+            return AllStates.Keys.ToArray()[index];
+        }
+
+        /// <summary>
+        ///     Implements the <see cref="T:System.Runtime.Serialization.ISerializable" /> interface and returns the data needed to
+        ///     serialize the <see cref="T:System.Collections.Specialized.NameObjectCollectionBase" /> instance.
+        /// </summary>
+        /// <param name="info">
+        ///     A <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object that contains the
+        ///     information required to serialize the <see cref="T:System.Collections.Specialized.NameObjectCollectionBase" />
+        ///     instance.
+        /// </param>
+        /// <param name="context">
+        ///     A <see cref="T:System.Runtime.Serialization.StreamingContext" /> object that contains the source
+        ///     and destination of the serialized stream associated with the
+        ///     <see cref="T:System.Collections.Specialized.NameObjectCollectionBase" /> instance.
+        /// </param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="info" /> is null.</exception>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            AllStates.GetObjectData(info, context);
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, locks access to objects in the collection in order to enable synchronized
+        ///     access.
+        /// </summary>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void Lock()
+        {
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, removes the named object from the collection.
+        /// </summary>
+        /// <param name="name">The name of the object to remove from the collection.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void Remove(string name)
+        {
+            AllStates.Remove(name);
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, removes all objects from the collection.
+        /// </summary>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void RemoveAll()
+        {
+            AllStates.Clear();
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, removes a state object specified by index from the collection.
+        /// </summary>
+        /// <param name="index">The position in the collection of the item to remove.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void RemoveAt(int index)
+        {
+            var key = GetKey(index);
+            AllStates.Remove(key);
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, updates the value of an object in the collection.
+        /// </summary>
+        /// <param name="name">The name of the object to update.</param>
+        /// <param name="value">The updated value of the object.</param>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void Set(string name, object value)
+        {
+            AllStates[name] = value;
+        }
+
+        /// <summary>
+        ///     When overridden in a derived class, unlocks access to objects in the collection to enable synchronized access.
+        /// </summary>
+        /// <exception cref="T:System.NotImplementedException">Always.</exception>
+        public override void UnLock()
+        {
+        }
+    }
+}

--- a/src/Web/FakeN.Web.csproj
+++ b/src/Web/FakeN.Web.csproj
@@ -41,18 +41,31 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FakeHttpContextBuilder.cs" />
+    <Compile Include="FakeHttpApplication.cs" />
     <Compile Include="FakeHttpCachePolicy.cs" />
     <Compile Include="FakeHttpContext.cs" />
+    <Compile Include="FakeHttpContextControl.cs" />
     <Compile Include="FakeHttpContextExtensions.cs" />
     <Compile Include="FakeHttpFileCollection.cs" />
     <Compile Include="FakeHttpPostedFile.cs" />
     <Compile Include="FakeHttpRequest.cs" />
+    <Compile Include="FakeHttpRequestBuilder.cs" />
+    <Compile Include="FakeHttpRequestControl.cs" />
     <Compile Include="FakeHttpResponse.cs" />
+    <Compile Include="FakeHttpResponseBuilder.cs" />
+    <Compile Include="FakeHttpResponseControl.cs" />
+    <Compile Include="FakeHttpServerUtilityBase.cs" />
     <Compile Include="FakeHttpSessionState.cs" />
     <Compile Include="FakeHttpSessionStateExtensions.cs" />
+    <Compile Include="FakeHttpStateBase.cs" />
+    <Compile Include="FakeRequestContext.cs" />
+    <Compile Include="Helper.cs" />
     <Compile Include="HttpObjectExtensions.cs" />
+    <Compile Include="IHttpObject.cs" />
     <Compile Include="MutableIdentity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TransferRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Web/FakeRequestContext.cs
+++ b/src/Web/FakeRequestContext.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Web;
+using System.Web.Routing;
+
+namespace FakeN.Web
+{
+    public class FakeRequestContext : RequestContext
+    {
+        public FakeRequestContext(FakeHttpContext httpContext)
+        {
+            if (httpContext == null) throw new ArgumentNullException("httpContext");
+            HttpContext = httpContext;
+            RouteData = new RouteData();
+        }
+
+        public FakeRequestContext()
+        {
+            RouteData = new RouteData();
+        }
+
+        /// <summary>
+        /// Gets information about the requested route.
+        /// </summary>
+        /// <returns>
+        /// An object that contains information about the requested route.
+        /// </returns>
+        public override RouteData RouteData { get; set; }
+
+        /// <summary>
+        /// Gets information about the HTTP request.
+        /// </summary>
+        /// <returns>
+        /// An object that contains information about the HTTP request.
+        /// </returns>
+        public override HttpContextBase HttpContext { get; set; }
+    }
+}

--- a/src/Web/Helper.cs
+++ b/src/Web/Helper.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace FakeN.Web
+{
+    public static class Helper
+    {
+        public static Dictionary<string, object> ToDictionary(object anonymous)
+        {
+            var items = new Dictionary<string, object>();
+            if (anonymous == null) 
+                return items;
+
+            foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(anonymous))
+            {
+                var obj2 = descriptor.GetValue(anonymous);
+                items.Add(descriptor.Name, obj2);
+            }
+            return items;
+        }
+
+        public static NameValueCollection ToNameValue(object anonymous)
+        {
+            var items = new NameValueCollection();
+            if (anonymous == null)
+                return items;
+
+            foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(anonymous))
+            {
+                var obj2 = descriptor.GetValue(anonymous);
+                items.Add(descriptor.Name, obj2 == null ? "" : obj2.ToString());
+            }
+            return items;
+        }
+    }
+}

--- a/src/Web/HttpObjectExtensions.cs
+++ b/src/Web/HttpObjectExtensions.cs
@@ -37,6 +37,20 @@ namespace FakeN.Web {
 
 			var member = body.Member;
 
+            //get ctrl class
+		    var ctrlProperty = req.GetType().GetProperty("Control");
+		    if (ctrlProperty != null)
+		    {
+		        var controlInstance = ctrlProperty.GetValue(req, null);
+		        var setter=ctrlProperty.PropertyType.GetProperty(member.Name);
+		        if (setter != null)
+		        {
+                    setter.SetValue(controlInstance, value, null);
+		            return;
+		        }
+
+		    }
+
 			//call set method if it exists
 			var setMethod = req.GetType().GetMethod("Set" + member.Name, new[] { typeof(T) });
 			if (setMethod != null) {

--- a/src/Web/IHttpObject.cs
+++ b/src/Web/IHttpObject.cs
@@ -1,0 +1,4 @@
+﻿namespace FakeN.Web
+{
+    public interface IHttpObject { }
+}

--- a/src/Web/TransferRequest.cs
+++ b/src/Web/TransferRequest.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Specialized;
+using System.Web;
+
+namespace FakeN.Web
+{
+    /// <summary>
+    ///     Container for <see cref="FakeHttpServerUtilityBase" />
+    /// </summary>
+    public class TransferRequest
+    {
+        public TransferRequest(IHttpHandler handler, bool preserveForm)
+        {
+            Handler = handler;
+            PreserveForm = preserveForm;
+        }
+
+        public TransferRequest(string path)
+        {
+            Path = path;
+        }
+
+        public TransferRequest(string path, bool preserveForm)
+        {
+            Path = path;
+            PreserveForm = preserveForm;
+        }
+
+        public TransferRequest(string path, bool preserveForm, string method, NameValueCollection headers)
+        {
+            Path = path;
+            PreserveForm = preserveForm;
+            Method = method;
+            Headers = headers;
+        }
+
+        public string Path { get; set; }
+        public IHttpHandler Handler { get; set; }
+        public bool PreserveForm { get; set; }
+        public string Method { get; set; }
+        public NameValueCollection Headers { get; set; }
+    }
+}

--- a/test/Web/ContextTests.cs
+++ b/test/Web/ContextTests.cs
@@ -18,7 +18,7 @@ namespace FakeN.Web.Test
 		{
 			context.Items.Add("color", "blue");
 
-			Assert.That(context.Items["color"], Is.EqualTo("blue"));
+            Assert.That(context.Items["color"], Is.EqualTo("blue"));
 		}
 	}
 }

--- a/test/Web/FakeN.Web.Test.csproj
+++ b/test/Web/FakeN.Web.Test.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HttpContextBuilderTests.cs" />
     <Compile Include="FileCollectionTests.cs" />
     <Compile Include="FormTests.cs" />
     <Compile Include="ContextTests.cs" />

--- a/test/Web/HttpContextBuilderTests.cs
+++ b/test/Web/HttpContextBuilderTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 
 namespace FakeN.Web.Test
 {
-   
+
     [TestFixture]
     public class HttpContextBuilderTests
     {
@@ -26,7 +26,7 @@ namespace FakeN.Web.Test
         {
             var httpContext = builder
                 .Post("http://localhost/?A=1")
-                .RespondWith(new {Status = "Ok"})
+                .RespondWith(new { Status = "Ok" })
                 .Build();
 
 
@@ -41,7 +41,7 @@ namespace FakeN.Web.Test
         public void assigns_session_correctly()
         {
             var httpContext = builder
-                .UsingSession(new {UserId = 10})
+                .UsingSession(new { UserId = 10 })
                 .Build();
 
 
@@ -52,7 +52,7 @@ namespace FakeN.Web.Test
         public void assigns_principal_correctly()
         {
             var httpContext = builder
-                .UsePrincipal(new GenericPrincipal(new GenericIdentity("Arne"), new []{"Admin"}))
+                .UsePrincipal(new GenericPrincipal(new GenericIdentity("Arne"), new[] { "Admin" }))
                 .Build();
 
 

--- a/test/Web/HttpContextBuilderTests.cs
+++ b/test/Web/HttpContextBuilderTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Principal;
+using System.Text;
+using NUnit.Framework;
+
+namespace FakeN.Web.Test
+{
+   
+    [TestFixture]
+    public class HttpContextBuilderTests
+    {
+        private FakeHttpContextBuilder builder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            builder = new FakeHttpContextBuilder();
+            FakeHttpContextBuilder.BodySerializer = o => "Hello";
+        }
+
+        [Test]
+        public void Can_create_a_basic_context()
+        {
+            var httpContext = builder
+                .Post("http://localhost/?A=1")
+                .RespondWith(new {Status = "Ok"})
+                .Build();
+
+
+            Assert.That(httpContext.Request.Url.ToString(), Is.EqualTo("http://localhost/?A=1"));
+
+            var reader = new StreamReader(httpContext.Response.OutputStream);
+            var text = reader.ReadToEnd();
+            Assert.That(text, Is.EqualTo("Hello"));
+        }
+
+        [Test]
+        public void assigns_session_correctly()
+        {
+            var httpContext = builder
+                .UsingSession(new {UserId = 10})
+                .Build();
+
+
+            Assert.That(httpContext.Session["UserId"], Is.EqualTo(10));
+        }
+
+        [Test]
+        public void assigns_principal_correctly()
+        {
+            var httpContext = builder
+                .UsePrincipal(new GenericPrincipal(new GenericIdentity("Arne"), new []{"Admin"}))
+                .Build();
+
+
+            Assert.That(httpContext.User.Identity.Name, Is.EqualTo("Arne"));
+        }
+    }
+}

--- a/test/Web/SessionTests.cs
+++ b/test/Web/SessionTests.cs
@@ -10,7 +10,11 @@ namespace FakeN.Web.Test
 		[Test]
 		public void Session_should_not_be_null()
 		{
-			Assert.That(new FakeHttpContext().Session, Is.Not.Null);
+
+		    var context = new FakeHttpContext();
+		    var session = context.Session;
+
+			Assert.That(context.Session, Is.Not.Null);
 		}
 
 		[Test]


### PR DESCRIPTION
I got `NullReferenceException` for different properties like the `InputStream`. Those shouldn't have to be configured by should be setup per default. This PR initializes all properties with relevant default values for request/response/context.

As an alternative to the `Get` extension method there is now a property for httpcontext/request/response called `Control` which exposes all properties as setters/getters. The syntax becomes a little bit cleaner (`request.Control.HttpMethod = "POST"`). All existing unit tests do of course pass with flying colors (i.e. I've tried to make everything backwards compatible).

Finally I've introduced a fluent syntax for using this library:

``` csharp
// simple context
var httpContext = builder
    .Post("http://localhost/?A=1")
    .WithForm(new { FirstName = "Jonas", LastName = "Gauffin", UserName = "jgauffin" })
    .RespondWith(403)
    .Build();

// configuring the session
var httpContext = builder
    .UsingSession(new {UserId = 10})
    .Build();

// setting principal
var principal ? new GenericPrincipal(new GenericIdentity("Arne"), new []{"Admin"});
var httpContext = builder
    .UsePrincipal(principal)
    .Build();
```
